### PR TITLE
Fix thread safety in TriggerObjects and IsolatedTracks

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
@@ -4,7 +4,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -18,7 +18,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 
-class TriggerObjectTableProducer : public edm::global::EDProducer<> {
+class TriggerObjectTableProducer : public edm::stream::EDProducer<> {
     public:
         explicit TriggerObjectTableProducer(const edm::ParameterSet &iConfig) :
             name_(iConfig.getParameter<std::string>("name")),
@@ -45,7 +45,7 @@ class TriggerObjectTableProducer : public edm::global::EDProducer<> {
         ~TriggerObjectTableProducer() override {}
 
     private:
-        void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override ;
+        void produce(edm::Event&, edm::EventSetup const&) override ;
 
         std::string name_;
         edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> src_;
@@ -89,7 +89,7 @@ class TriggerObjectTableProducer : public edm::global::EDProducer<> {
 
 // ------------ method called to produce the data  ------------
 void
-TriggerObjectTableProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const 
+TriggerObjectTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 {
 
     edm::Handle<std::vector<pat::TriggerObjectStandAlone>> src;

--- a/PhysicsTools/PatAlgos/plugins/IsolatedTrackCleaner.cc
+++ b/PhysicsTools/PatAlgos/plugins/IsolatedTrackCleaner.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -10,7 +10,7 @@
 #include <vector>
 
 
-class IsolatedTrackCleaner : public edm::global::EDProducer<> {
+class IsolatedTrackCleaner : public edm::stream::EDProducer<> {
     public:
         IsolatedTrackCleaner( edm::ParameterSet const & params ) :
             tracks_(consumes<std::vector<pat::IsolatedTrack>>(params.getParameter<edm::InputTag>("tracks"))),
@@ -24,7 +24,7 @@ class IsolatedTrackCleaner : public edm::global::EDProducer<> {
 
         ~IsolatedTrackCleaner() override {}
 
-        void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
+        void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
             auto out  = std::make_unique<std::vector<pat::IsolatedTrack>>();
 
             std::vector<reco::CandidatePtr> leptonPfCands;


### PR DESCRIPTION
Convert +TriggerObjectTableProducer and IsolatedTrackCleaner to edm::stream to address non-thread-safety of StringParser

for #44 