### PR TITLE
modifying sequences for FastSim nanoAOD production

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1008,6 +1008,8 @@ class ConfigBuilder(object):
                 self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineMC_cff"
                 self.ALCADefaultCFF="Configuration/StandardSequences/AlCaRecoStreamsMC_cff"
 	        self.NANODefaultSeq='nanoSequenceMC'
+        if self._options.fast == True:
+            self.NANODefaultSeq='nanoSequenceFS'
 	else:
 		self._options.beamspot = None
 	

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -129,6 +129,9 @@ nanoSequence = cms.Sequence(
 
 nanoSequenceMC = cms.Sequence(genParticleSequence + particleLevelSequence + nanoSequence + jetMC + muonMC + electronMC + photonMC + tauMC + metMC + ttbarCatMCProducers +  globalTablesMC + btagWeightTable + genWeightsTable + genParticleTables + particleLevelTables + lheInfoTable  + ttbarCategoryTable )
 
+nanoSequenceFS = nanoSequenceMC.copy()
+nanoSequenceFS.remove(triggerObjectTables)
+nanoSequenceFS.remove(l1bits)
 
 from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
 from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
@@ -208,6 +211,13 @@ _80x_sequence.insert(_80x_sequence.index(jetSequence), extraFlagsProducers)
 _80x_sequence.insert(_80x_sequence.index(l1bits)+1, extraFlagsTable)
 
 run2_miniAOD_80XLegacy.toReplaceWith( nanoSequence, _80x_sequence)
+
+_80x_sequenceFS = nanoSequenceFS.copy()
+_80x_sequenceFS.remove(isoTrackTable)
+_80x_sequenceFS.remove(isoTrackSequence)
+_80x_sequenceFS.insert(_80x_sequenceFS.index(jetSequence), extraFlagsProducers)
+_80x_sequenceFS.insert(_80x_sequenceFS.index(simpleCleanerTable)+1, extraFlagsTable)
+run2_miniAOD_80XLegacy.toReplaceWith( nanoSequenceFS, _80x_sequenceFS)
 
 	
 


### PR DESCRIPTION
Adressing part of #198 
`--fast` flag in cmsDriver now removes parts from the sequence that don't run on FastSim samples.