### PR TITLE
Add trk chs met

### DIFF
--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -80,8 +80,8 @@ chsMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     singleton = cms.bool(True),  # there's always exactly one MET per event
     extension = cms.bool(False), # this is the main table for the TkMET
     variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
-       pt = Var("corPt('RawChs')", float, doc="chs PF MET pt",precision=10),
-       phi = Var("corPhi('RawChs')", float, doc="chs PF MET phi",precision=10),
+       pt = Var("corPt('RawChs')", float, doc="raw chs PF MET pt",precision=10),
+       phi = Var("corPhi('RawChs')", float, doc="raw chs PF MET phi",precision=10),
        sumEt = Var("corSumEt('RawChs')", float, doc="raw chs PF scalar sum of Et",precision=10),
     ),
 )

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -2,19 +2,6 @@ import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.common_cff import *
 
 
-
-##################### User floats producers, selectors ##########################
-## this can be merged with chsFor soft activity if we keep the same selection
-chsForTkMet = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string('charge()!=0 && pvAssociationQuality()>=5 && vertexRef().key()==0'))
-tkMet = cms.EDProducer("PFMETProducer",
-    src = cms.InputTag("chsForTkMet"),
-    alias = cms.string('tkMet'),
-    globalThreshold = cms.double(0.0),
-    calculateSignificance = cms.bool(False),
-)
-
-
-
 ##################### Tables for final output and docs ##########################
 metTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("slimmedMETs"),
@@ -74,16 +61,30 @@ puppiMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 
 tkMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
-    src = cms.InputTag("tkMet"),
+    src = metTable.src,
     name = cms.string("TkMET"),
-    doc = cms.string("Track MET computed with tracks from PV0 ( pvAssociationQuality()>=5 ) "),
+    doc = cms.string("Track MET computed with tracks from PV0 ( pvAssociationQuality()>=4 ) "),
     singleton = cms.bool(True),  # there's always exactly one MET per event
     extension = cms.bool(False), # this is the main table for the TkMET
-    variables = cms.PSet(PTVars,
-       sumEt = Var("sumEt()", float, doc="scalar sum of Et",precision=10),
+    variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
+       pt = Var("corPt('RawTrk')", float, doc="raw track MET pt",precision=10),
+       phi = Var("corPhi('RawTrk')", float, doc="raw track MET phi",precision=10),
+       sumEt = Var("corSumEt('RawTrk')", float, doc="raw track scalar sum of Et",precision=10),
     ),
 )
 
+chsMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    src = metTable.src,
+    name = cms.string("ChsMET"),
+    doc = cms.string("PF MET computed with CHS PF candidates"),
+    singleton = cms.bool(True),  # there's always exactly one MET per event
+    extension = cms.bool(False), # this is the main table for the TkMET
+    variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
+       pt = Var("corPt('RawChs')", float, doc="chs PF MET pt",precision=10),
+       phi = Var("corPhi('RawChs')", float, doc="chs PF MET phi",precision=10),
+       sumEt = Var("corSumEt('RawChs')", float, doc="raw chs PF scalar sum of Et",precision=10),
+    ),
+)
 
 metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = metTable.src,
@@ -99,7 +100,7 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 
-metSequence = cms.Sequence(chsForTkMet+tkMet)
-metTables = cms.Sequence( metTable + rawMetTable + caloMetTable + puppiMetTable + tkMetTable)
+#metSequence = cms.Sequence(chsForTkMet+tkMet)
+metTables = cms.Sequence( metTable + rawMetTable + caloMetTable + puppiMetTable + tkMetTable + chsMetTable)
 metMC = cms.Sequence( metMCTable )
 

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -100,7 +100,6 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 
-#metSequence = cms.Sequence(chsForTkMet+tkMet)
 metTables = cms.Sequence( metTable + rawMetTable + caloMetTable + puppiMetTable + tkMetTable + chsMetTable)
 metMC = cms.Sequence( metMCTable )
 

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -13,6 +13,14 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('sumEt', 'sumEt', 20, 200, 3000, 'scalar sum of Et'),
             )
         ),
+        ChsMET = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'raw chs PF MET phi'),
+                Plot1D('pt', 'pt', 20, 0, 400, 'raw chs PF MET pt'),
+                Plot1D('sumEt', 'sumEt', 20, 600, 5000, 'raw chs PF scalar sum of Et'),
+            )
+        ),
         Electron = cms.PSet(
             sels = cms.PSet(
                 Good = cms.string('pt > 15 && abs(dxy) < 0.2 && abs(dz) < 0.5 && cutBased >= 3 && miniPFRelIso_all < 0.4')

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -124,7 +124,7 @@ lheInfoTable = cms.EDProducer("LHETablesProducer",
 l1bits=cms.EDProducer("L1TriggerResultsConverter", src=cms.InputTag("gtStage2Digis"), legacyL1=cms.bool(False))
 
 nanoSequence = cms.Sequence(
-        nanoMetadata + jetSequence + muonSequence + tauSequence + electronSequence+photonSequence+vertexSequence+metSequence+
+        nanoMetadata + jetSequence + muonSequence + tauSequence + electronSequence+photonSequence+vertexSequence+
         isoTrackSequence + # must be after all the leptons 
         linkedObjects  +
         jetTables + muonTables + tauTables + electronTables + photonTables +  globalTables +vertexTables+ metTables+simpleCleanerTable + triggerObjectTables + isoTrackTables +


### PR DESCRIPTION
Store chsMET from miniAOD. Modify to read trkMET from miniAOD instead of recalculating. Previously, the trkMET that was being calculated in nanoAOD used a different charged PF candidate selection than that used in the miniAOD.