### PR TITLE
Fixes to AK8 treatment for 80X samples

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -383,7 +383,6 @@ run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau3, expr = cms.string("
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, tau4 = None)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n2b1 = None)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n3b1 = None)
-run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, btagCMVA = None, btagDeepB = None)
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
     modifier.toModify( fatJetTable.variables, jetId = Var("userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight"))
 
@@ -424,6 +423,7 @@ run2_miniAOD_80XLegacy.toModify( subJetTable.variables, tau3 = None)
 run2_miniAOD_80XLegacy.toModify( subJetTable.variables, tau4 = None)
 run2_miniAOD_80XLegacy.toModify( subJetTable.variables, n2b1 = None)
 run2_miniAOD_80XLegacy.toModify( subJetTable.variables, n3b1 = None)
+run2_miniAOD_80XLegacy.toModify( subJetTable.variables, btagCMVA = None, btagDeepB = None)
 
 run2_nanoAOD_92X.toModify( subJetTable.variables, tau4 = None)
 run2_nanoAOD_92X.toModify( subJetTable.variables, n2b1 = None)

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -383,6 +383,7 @@ run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau3, expr = cms.string("
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, tau4 = None)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n2b1 = None)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n3b1 = None)
+run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, btagCMVA = None, btagDeepB = None)
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
     modifier.toModify( fatJetTable.variables, jetId = Var("userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight"))
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -142,6 +142,7 @@ jetCorrFactorsAK8 = patJetCorrFactors.clone(src='slimmedJetsAK8WithUserData',
     payload = cms.string('AK8PFPuppi'),
     primaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
 )
+run2_miniAOD_80XLegacy.toModify(jetCorrFactorsAK8, payload = cms.string('AK8PFchs')) # ak8PFJetsCHS in 2016 80X miniAOD
 
 from  PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cfi import *
 updatedJets = updatedPatJets.clone(

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -379,9 +379,9 @@ run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, msoftdrop_chs = Var("use
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau1, expr = cms.string("userFloat(\'ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1\')"),)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau2, expr = cms.string("userFloat(\'ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2\')"),)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau3, expr = cms.string("userFloat(\'ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3\')"),)
-run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau4, expr = cms.string("-1"),)
-run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.n2b1, expr = cms.string("-1"),)
-run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.n3b1, expr = cms.string("-1"),)
+run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, tau4 = None)
+run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n2b1 = None)
+run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n3b1 = None)
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
     modifier.toModify( fatJetTable.variables, jetId = Var("userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight"))
 
@@ -416,12 +416,12 @@ subJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 fatJetTable.variables.pt.precision=10
 subJetTable.variables.pt.precision=10
 
-run2_miniAOD_80XLegacy.toModify( subJetTable.variables.tau1, expr = cms.string("-1"),)
-run2_miniAOD_80XLegacy.toModify( subJetTable.variables.tau2, expr = cms.string("-1"),)
-run2_miniAOD_80XLegacy.toModify( subJetTable.variables.tau3, expr = cms.string("-1"),)
-run2_miniAOD_80XLegacy.toModify( subJetTable.variables.tau4, expr = cms.string("-1"),)
-run2_miniAOD_80XLegacy.toModify( subJetTable.variables.n2b1, expr = cms.string("-1"),)
-run2_miniAOD_80XLegacy.toModify( subJetTable.variables.n3b1, expr = cms.string("-1"),)
+run2_miniAOD_80XLegacy.toModify( subJetTable.variables, tau1 = None)
+run2_miniAOD_80XLegacy.toModify( subJetTable.variables, tau2 = None)
+run2_miniAOD_80XLegacy.toModify( subJetTable.variables, tau3 = None)
+run2_miniAOD_80XLegacy.toModify( subJetTable.variables, tau4 = None)
+run2_miniAOD_80XLegacy.toModify( subJetTable.variables, n2b1 = None)
+run2_miniAOD_80XLegacy.toModify( subJetTable.variables, n3b1 = None)
 
 run2_nanoAOD_92X.toModify( subJetTable.variables.tau4, expr = cms.string("-1"),)
 run2_nanoAOD_92X.toModify( subJetTable.variables.n2b1, expr = cms.string("-1"),)

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -387,9 +387,9 @@ run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, btagCMVA = None, btagDee
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
     modifier.toModify( fatJetTable.variables, jetId = Var("userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight"))
 
-run2_nanoAOD_92X.toModify( fatJetTable.variables.tau4, expr = cms.string("-1"),)
-run2_nanoAOD_92X.toModify( fatJetTable.variables.n2b1, expr = cms.string("-1"),)
-run2_nanoAOD_92X.toModify( fatJetTable.variables.n3b1, expr = cms.string("-1"),)
+run2_nanoAOD_92X.toModify( fatJetTable.variables, tau4 = None)
+run2_nanoAOD_92X.toModify( fatJetTable.variables, n2b1 = None)
+run2_nanoAOD_92X.toModify( fatJetTable.variables, n3b1 = None)
 
 
 
@@ -425,9 +425,9 @@ run2_miniAOD_80XLegacy.toModify( subJetTable.variables, tau4 = None)
 run2_miniAOD_80XLegacy.toModify( subJetTable.variables, n2b1 = None)
 run2_miniAOD_80XLegacy.toModify( subJetTable.variables, n3b1 = None)
 
-run2_nanoAOD_92X.toModify( subJetTable.variables.tau4, expr = cms.string("-1"),)
-run2_nanoAOD_92X.toModify( subJetTable.variables.n2b1, expr = cms.string("-1"),)
-run2_nanoAOD_92X.toModify( subJetTable.variables.n3b1, expr = cms.string("-1"),)
+run2_nanoAOD_92X.toModify( subJetTable.variables, tau4 = None)
+run2_nanoAOD_92X.toModify( subJetTable.variables, n2b1 = None)
+run2_nanoAOD_92X.toModify( subJetTable.variables, n3b1 = None)
 
 
 

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -61,6 +61,7 @@ for modifier in eras.run2_miniAOD_80XLegacy, eras.run2_nanoAOD_94X2016:
 eras.run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.FatJet, plots = _FatJet_plots_80x)
 eras.run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.Flag, plots = _Flag_plots_80x)
 
+eras.run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots, IsoTrack = None)
 
 ## MC
 nanoDQMMC = nanoDQM.clone()

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -157,19 +157,21 @@ def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
                jetSource = cms.InputTag('slimmedJets'),
                jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']), 'None'),
                btagDiscriminators = _btagDiscriminators,
-               btagPrefix = ''
+               postfix = 'WithDeepInfo',
            )
     process.load("Configuration.StandardSequences.MagneticField_cff")
-    process.looseJetId.src="selectedUpdatedPatJets"
-    process.tightJetId.src="selectedUpdatedPatJets"
-    process.tightJetIdLepVeto.src="selectedUpdatedPatJets"
-    process.bJetVars.src="selectedUpdatedPatJets"
-    process.slimmedJetsWithUserData.src="selectedUpdatedPatJets"
-    process.qgtagger80x.srcJets="selectedUpdatedPatJets"
+    process.looseJetId.src="selectedUpdatedPatJetsWithDeepInfo"
+    process.tightJetId.src="selectedUpdatedPatJetsWithDeepInfo"
+    process.tightJetIdLepVeto.src="selectedUpdatedPatJetsWithDeepInfo"
+    process.bJetVars.src="selectedUpdatedPatJetsWithDeepInfo"
+    process.slimmedJetsWithUserData.src="selectedUpdatedPatJetsWithDeepInfo"
+    process.qgtagger80x.srcJets="selectedUpdatedPatJetsWithDeepInfo"
     if addDeepFlavour:
         process.pfDeepFlavourJetTags.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
         process.pfDeepFlavourJetTags.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]
     patAlgosToolsTask = getPatAlgosToolsTask(process)
+    patAlgosToolsTask.add(process.updatedPatJetsWithDeepInfo)
+    patAlgosToolsTask.add(process.patJetCorrFactorsWithDeepInfo)
     process.additionalendpath = cms.EndPath(patAlgosToolsTask)
     return process
 
@@ -220,16 +222,18 @@ def nanoAOD_addDeepInfoAK8(process,addDeepBTag,addDeepBoostedJet,jecPayload):
        pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
        svSource = cms.InputTag('slimmedSecondaryVertices'),
        rParam = 0.8,
-       jetCorrections = (jecPayload, cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None'),
+       jetCorrections = (jecPayload.value(), cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None'),
        btagDiscriminators = _btagDiscriminators,
-       postfix='AK8',
+       postfix='AK8WithDeepInfo',
        printWarning = False
        )
-    process.looseJetIdAK8.src = "selectedUpdatedPatJetsAK8"
-    process.tightJetIdAK8.src = "selectedUpdatedPatJetsAK8"
-    process.tightJetIdLepVetoAK8.src = "selectedUpdatedPatJetsAK8"
-    process.slimmedJetsAK8WithUserData.src = "selectedUpdatedPatJetsAK8"
+    process.looseJetIdAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
+    process.tightJetIdAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
+    process.tightJetIdLepVetoAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
+    process.slimmedJetsAK8WithUserData.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
     patAlgosToolsTask = getPatAlgosToolsTask(process)
+    patAlgosToolsTask.add(process.updatedPatJetsAK8WithDeepInfo)
+    patAlgosToolsTask.add(process.patJetCorrFactorsAK8WithDeepInfo)
     process.additionalendpath = cms.EndPath(patAlgosToolsTask)
     return process
 
@@ -250,13 +254,13 @@ def nanoAOD_customizeCommon(process):
     nanoAOD_addDeepInfoAK8_switch = cms.PSet(
         nanoAOD_addDeepBTag_switch = cms.untracked.bool(False),
         nanoAOD_addDeepBoostedJet_switch = cms.untracked.bool(True), # will deactivate this in future miniAOD releases
-        jecPayload = 'AK8PFPuppi'
+        jecPayload = cms.untracked.string('AK8PFPuppi')
         )
     # deepAK8 should not run on 80X, that contains ak8PFJetsCHS jets
     run2_miniAOD_80XLegacy.toModify(nanoAOD_addDeepInfoAK8_switch,
                                     nanoAOD_addDeepBTag_switch = cms.untracked.bool(True),
                                     nanoAOD_addDeepBoostedJet_switch = cms.untracked.bool(False),
-                                    jecPayload = 'AK8PFchs')
+                                    jecPayload = cms.untracked.string('AK8PFchs'))
     process = nanoAOD_addDeepInfoAK8(process,
                                      addDeepBTag=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBTag_switch,
                                      addDeepBoostedJet=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBoostedJet_switch,

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -233,6 +233,7 @@ def nanoAOD_addDeepInfoAK8(process,addDeepBTag,addDeepBoostedJet,jecPayload):
     process.additionalendpath = cms.EndPath(patAlgosToolsTask)
     return process
 
+
 def nanoAOD_customizeCommon(process):
 #    makePuppiesFromMiniAOD(process,True) # call this here as it calls switchOnVIDPhotonIdProducer
     process = nanoAOD_activateVID(process)
@@ -243,7 +244,9 @@ def nanoAOD_customizeCommon(process):
     run2_miniAOD_80XLegacy.toModify(nanoAOD_addDeepInfo_switch, nanoAOD_addDeepBTag_switch = cms.untracked.bool(True))
     for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
         modifier.toModify(nanoAOD_addDeepInfo_switch, nanoAOD_addDeepFlavourTag_switch =  cms.untracked.bool(True))
-    process = nanoAOD_addDeepInfo(process,addDeepBTag=nanoAOD_addDeepInfo_switch.nanoAOD_addDeepBTag_switch,addDeepFlavour=nanoAOD_addDeepInfo_switch.nanoAOD_addDeepFlavourTag_switch)
+    process = nanoAOD_addDeepInfo(process,
+                                  addDeepBTag=nanoAOD_addDeepInfo_switch.nanoAOD_addDeepBTag_switch,
+                                  addDeepFlavour=nanoAOD_addDeepInfo_switch.nanoAOD_addDeepFlavourTag_switch)
     nanoAOD_addDeepInfoAK8_switch = cms.PSet(
         nanoAOD_addDeepBTag_switch = cms.untracked.bool(False),
         nanoAOD_addDeepBoostedJet_switch = cms.untracked.bool(True), # will deactivate this in future miniAOD releases
@@ -254,7 +257,10 @@ def nanoAOD_customizeCommon(process):
                                     nanoAOD_addDeepBTag_switch = cms.untracked.bool(True),
                                     nanoAOD_addDeepBoostedJet_switch = cms.untracked.bool(False),
                                     jecPayload = 'AK8PFchs')
-    process = nanoAOD_addDeepInfoAK8(process,addDeepBTag=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBTag_switch,addDeepBoostedJet=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBoostedJet_switch)
+    process = nanoAOD_addDeepInfoAK8(process,
+                                     addDeepBTag=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBTag_switch,
+                                     addDeepBoostedJet=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBoostedJet_switch,
+                                     jecPayload=nanoAOD_addDeepInfoAK8_switch.jecPayload)
     return process
 
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -203,7 +203,7 @@ def nanoAOD_activateVID(process):
     process.photonSequence.insert(process.photonSequence.index(bitmapVIDForPho),process.egmPhotonIDSequence)
     return process
 
-def nanoAOD_addDeepInfoAK8(process,addDeepBTag,addDeepBoostedJet):
+def nanoAOD_addDeepInfoAK8(process,addDeepBTag,addDeepBoostedJet,jecPayload):
     _btagDiscriminators=[]
     if addDeepBTag:
         print("Updating process to run DeepCSV btag to AK8 jets")
@@ -220,15 +220,15 @@ def nanoAOD_addDeepInfoAK8(process,addDeepBTag,addDeepBoostedJet):
        pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
        svSource = cms.InputTag('slimmedSecondaryVertices'),
        rParam = 0.8,
-       jetCorrections = ('AK8PFPuppi', cms.vstring(['L2Relative', 'L3Absolute', 'L2L3Residual']), 'None'),
+       jetCorrections = (jecPayload, cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None'),
        btagDiscriminators = _btagDiscriminators,
-       postfix='AK8Puppi',
+       postfix='AK8',
        printWarning = False
        )
-    process.looseJetIdAK8.src = "selectedUpdatedPatJetsAK8Puppi"
-    process.tightJetIdAK8.src = "selectedUpdatedPatJetsAK8Puppi"
-    process.tightJetIdLepVetoAK8.src = "selectedUpdatedPatJetsAK8Puppi"
-    process.slimmedJetsAK8WithUserData.src = "selectedUpdatedPatJetsAK8Puppi"
+    process.looseJetIdAK8.src = "selectedUpdatedPatJetsAK8"
+    process.tightJetIdAK8.src = "selectedUpdatedPatJetsAK8"
+    process.tightJetIdLepVetoAK8.src = "selectedUpdatedPatJetsAK8"
+    process.slimmedJetsAK8WithUserData.src = "selectedUpdatedPatJetsAK8"
     patAlgosToolsTask = getPatAlgosToolsTask(process)
     process.additionalendpath = cms.EndPath(patAlgosToolsTask)
     return process
@@ -247,8 +247,13 @@ def nanoAOD_customizeCommon(process):
     nanoAOD_addDeepInfoAK8_switch = cms.PSet(
         nanoAOD_addDeepBTag_switch = cms.untracked.bool(False),
         nanoAOD_addDeepBoostedJet_switch = cms.untracked.bool(True), # will deactivate this in future miniAOD releases
+        jecPayload = 'AK8PFPuppi'
         )
-    run2_miniAOD_80XLegacy.toModify(nanoAOD_addDeepInfoAK8_switch, nanoAOD_addDeepBTag_switch = cms.untracked.bool(True))
+    # deepAK8 should not run on 80X, that contains ak8PFJetsCHS jets
+    run2_miniAOD_80XLegacy.toModify(nanoAOD_addDeepInfoAK8_switch,
+                                    nanoAOD_addDeepBTag_switch = cms.untracked.bool(True),
+                                    nanoAOD_addDeepBoostedJet_switch = cms.untracked.bool(False),
+                                    jecPayload = 'AK8PFchs')
     process = nanoAOD_addDeepInfoAK8(process,addDeepBTag=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBTag_switch,addDeepBoostedJet=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBoostedJet_switch)
     return process
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -167,8 +167,8 @@ def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
     process.slimmedJetsWithUserData.src="selectedUpdatedPatJetsWithDeepInfo"
     process.qgtagger80x.srcJets="selectedUpdatedPatJetsWithDeepInfo"
     if addDeepFlavour:
-        process.pfDeepFlavourJetTags.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
-        process.pfDeepFlavourJetTags.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]
+        process.pfDeepFlavourJetTagsWithDeepInfo.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
+        process.pfDeepFlavourJetTagsWithDeepInfo.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]
     patAlgosToolsTask = getPatAlgosToolsTask(process)
     patAlgosToolsTask.add(process.updatedPatJetsWithDeepInfo)
     patAlgosToolsTask.add(process.patJetCorrFactorsWithDeepInfo)


### PR DESCRIPTION
For fat jets in 80X samples:
- use AK8PFchs JEC payload
- run deepCSV
- don't run deepAK8 that is meant for PUPPI jets

@hqucms @gouskos @clelange