### PR TITLE
Prototype implementation of L1 prefiring event weight in NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
+from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv1_cff import run2_nanoAOD_94XMiniAODv1
+from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv2_cff import run2_nanoAOD_94XMiniAODv2
+from PhysicsTools.NanoAOD.common_cff import ExtVar
 import copy
 
 unpackedPatTrigger = cms.EDProducer("PATTriggerObjectStandAloneUnpacker",
@@ -158,4 +162,21 @@ run2_miniAOD_80XLegacy.toModify(
   selections = selections80X
 )
 
+from L1Prefiring.EventWeightProducer.L1ECALPrefiringWeightProducer_cfi import prefiringweight
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
+    modifier.toModify(prefiringweight, DataEra = cms.string("2016BtoH"))
+
+l1PreFiringEventWeightTable = cms.EDProducer("GlobalVariablesTableProducer",
+    variables = cms.PSet(
+        L1PreFiringWeight = ExtVar(cms.InputTag("prefiringweight:NonPrefiringProb"), "double", doc = "L1 pre-firing event correction weight (1-probability)", precision=8),
+        L1PreFiringWeightUp = ExtVar(cms.InputTag("prefiringweight:NonPrefiringProbUp"), "double", doc = "L1 pre-firing event correction weight (1-probability), up var.", precision=8),
+        L1PreFiringWeightDn = ExtVar(cms.InputTag("prefiringweight:NonPrefiringProbDown"), "double", doc = "L1 pre-firing event correction weight (1-probability), down var.", precision=8),
+    )
+)
+
 triggerObjectTables = cms.Sequence( unpackedPatTrigger + triggerObjectTable )
+
+_triggerObjectTables_withL1PreFiring = triggerObjectTables.copy()
+_triggerObjectTables_withL1PreFiring.replace(triggerObjectTable, prefiringweight + l1PreFiringEventWeightTable + triggerObjectTable)
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
+    modifier.toReplaceWith(triggerObjectTables, _triggerObjectTables_withL1PreFiring)


### PR DESCRIPTION
#264, needs functionality in cms-sw#25380