### PR TITLE
QGL and jet ID updates

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -531,7 +531,7 @@ from RecoJets.JetProducers.QGTagger_cfi import  QGTagger
 qgtagger=QGTagger.clone(srcJets="updatedJets",srcVertexCollection="offlineSlimmedPrimaryVertices")
 
 #before cross linking
-jetSequence = cms.Sequence(jetCorrFactorsNano+updatedJets+tightJetId+tightJetIdLepVeto+bJetVars+updatedJetsWithUserData+qgtagger+jetCorrFactorsAK8+updatedJetsAK8+tightJetIdAK8+tightJetIdLepVetoAK8+updatedJetsAK8WithUserData+chsForSATkJets+softActivityJets+softActivityJets2+softActivityJets5+softActivityJets10+finalJets+finalJetsAK8)
+jetSequence = cms.Sequence(jetCorrFactorsNano+updatedJets+tightJetId+tightJetIdLepVeto+bJetVars+qgtagger+updatedJetsWithUserData+jetCorrFactorsAK8+updatedJetsAK8+tightJetIdAK8+tightJetIdLepVetoAK8+updatedJetsAK8WithUserData+chsForSATkJets+softActivityJets+softActivityJets2+softActivityJets5+softActivityJets10+finalJets+finalJetsAK8)
 
 _jetSequence_2016 = jetSequence.copy()
 _jetSequence_2016.insert(_jetSequence_2016.index(tightJetId), looseJetId)

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -161,7 +161,7 @@ def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
     process.tightJetIdLepVeto.src="selectedUpdatedPatJetsWithDeepInfo"
     process.bJetVars.src="selectedUpdatedPatJetsWithDeepInfo"
     process.slimmedJetsWithUserData.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.qgtagger80x.srcJets="selectedUpdatedPatJetsWithDeepInfo"
+    process.qgtagger.srcJets="selectedUpdatedPatJetsWithDeepInfo"
     if addDeepFlavour:
         process.pfDeepFlavourJetTagsWithDeepInfo.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
         process.pfDeepFlavourJetTagsWithDeepInfo.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -156,12 +156,8 @@ def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
                postfix = 'WithDeepInfo',
            )
     process.load("Configuration.StandardSequences.MagneticField_cff")
-    process.looseJetId.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.tightJetId.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.tightJetIdLepVeto.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.bJetVars.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.updatedJetsWithUserData.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.qgtagger.srcJets="selectedUpdatedPatJetsWithDeepInfo"
+    process.jetCorrFactorsNano.src="selectedUpdatedPatJetsWithDeepInfo"
+    process.updatedJets.jetSource="selectedUpdatedPatJetsWithDeepInfo"
     if addDeepFlavour:
         process.pfDeepFlavourJetTagsWithDeepInfo.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
         process.pfDeepFlavourJetTagsWithDeepInfo.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]
@@ -219,10 +215,8 @@ def nanoAOD_addDeepInfoAK8(process,addDeepBTag,addDeepBoostedJet,jecPayload):
        postfix='AK8WithDeepInfo',
        printWarning = False
        )
-    process.looseJetIdAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
-    process.tightJetIdAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
-    process.tightJetIdLepVetoAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
-    process.updatedJetsAK8WithUserData.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
+    process.jetCorrFactorsAK8.src="selectedUpdatedPatJetsAK8WithDeepInfo"
+    process.updatedJetsAK8.jetSource="selectedUpdatedPatJetsAK8WithDeepInfo"
     return process
 
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -160,7 +160,7 @@ def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
     process.tightJetId.src="selectedUpdatedPatJetsWithDeepInfo"
     process.tightJetIdLepVeto.src="selectedUpdatedPatJetsWithDeepInfo"
     process.bJetVars.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.slimmedJetsWithUserData.src="selectedUpdatedPatJetsWithDeepInfo"
+    process.updatedJetsWithUserData.src="selectedUpdatedPatJetsWithDeepInfo"
     process.qgtagger.srcJets="selectedUpdatedPatJetsWithDeepInfo"
     if addDeepFlavour:
         process.pfDeepFlavourJetTagsWithDeepInfo.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
@@ -222,7 +222,7 @@ def nanoAOD_addDeepInfoAK8(process,addDeepBTag,addDeepBoostedJet,jecPayload):
     process.looseJetIdAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
     process.tightJetIdAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
     process.tightJetIdLepVetoAK8.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
-    process.slimmedJetsAK8WithUserData.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
+    process.updatedJetsAK8WithUserData.src = "selectedUpdatedPatJetsAK8WithDeepInfo"
     return process
 
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD


### PR DESCRIPTION
- rerun QGL on all datasets to pick up updated training from the GT
- save newly-implemented WINTER16 tightLepVeto working point in 2016 samples
(will be the same as tight in the validation area until cms-sw#25306 is backported and merged)

#211 @kschweiger @zdemirag @ahinzmann