### PR TITLE
Fix module label in IsFromLostTrackMapProducer::fillDescriptions()

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/IsFromLostTrackMapProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/IsFromLostTrackMapProducer.cc
@@ -122,9 +122,7 @@ void IsFromLostTrackMapProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("packedPFCandidates")->setComment("packed PF Candidates collection ");
   desc.add<edm::InputTag>("lostTracks")->setComment("lost tracks collection");
 
-  std::string modname;
-  modname="isFromLostTrack map producer";
-  descriptions.add(modname,desc);
+  descriptions.addWithDefaultLabel(desc);
 
 }
 


### PR DESCRIPTION
Originally from https://github.com/cms-sw/cmssw/pull/25588

Fixes scram complaints
```
/bin/cp: cannot stat `tmp/slc6_amd64_gcc700/src/PhysicsTools/NanoAOD/plugins/PhysicsToolsNanoAODPlugins/edm_write_config/isFromLostTrack': No such file or directory
/bin/cp: cannot stat `tmp/slc6_amd64_gcc700/src/PhysicsTools/NanoAOD/plugins/PhysicsToolsNanoAODPlugins/edm_write_config/map': No such file or directory
/bin/cp: cannot stat `tmp/slc6_amd64_gcc700/src/PhysicsTools/NanoAOD/plugins/PhysicsToolsNanoAODPlugins/edm_write_config/producer_cfi.py': No such file or directory
```