### PR TITLE
Remove trigger object redundancy of OverlapFilterIsoEle bits

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -40,7 +40,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                               "8*filter('*OverlapFilterIsoEle*PFTau*') + " \
                               "16*filter('hltEle*Ele*CaloIdLTrackIdLIsoVL*Filter') + " \
                               "32*filter('hltMu*TrkIsoVVL*Ele*CaloIdLTrackIdLIsoVL*Filter*')  + " \
-                              "64*filter('*OverlapFilterIsoEle*PFTau*') + " \
+                              "64*filter('hltOverlapFilterIsoEle*PFTau*') + " \
                               "128*filter('hltEle*Ele*Ele*CaloIdLTrackIdLDphiLeg*Filter') + " \
                               "256*max(filter('hltL3fL1Mu*DoubleEG*Filtered*'),filter('hltMu*DiEle*CaloIdLTrackIdLElectronleg*Filter')) + " \
                               "512*max(filter('hltL3fL1DoubleMu*EG*Filter*'),filter('hltDiMu*Ele*CaloIdLTrackIdLElectronleg*Filter')) + " \


### PR DESCRIPTION
Filter bit 8 and 64 for the electron trigger object are the same:
https://github.com/cms-nanoAOD/cmssw/blob/ff7a0071822a13968568947d24be361ff90e345e/PhysicsTools/NanoAOD/python/triggerObjects_cff.py#L40-L43
So analogous to bits 4 and 64 for the muon,
https://github.com/cms-nanoAOD/cmssw/blob/ff7a0071822a13968568947d24be361ff90e345e/PhysicsTools/NanoAOD/python/triggerObjects_cff.py#L67-L71
I redefined the electron's bit 64 to
```
    "64*filter('hltOverlapFilterIsoEle*PFTau*') + " \
```
This bit is useful to exclude the HPS tau filters employed in 2018 when matching the lepton leg, e.g.
<pre>
<b>hltOverlapFilterIsoEle</b>24WPTightGsfLooseIsoPFTau30
  -> HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1

<b>hltHpsOverlapFilterIsoEle</b>24WPTightGsfLooseIsoPFTau30
  -> HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTauHPS30_eta2p1_CrossL1

<b>hltOverlapFilterIsoMu</b>20LooseChargedIsoPFTau27L1Seeded
  -> HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1

<b>hltHpsOverlapFilterIsoMu</b>20LooseChargedIsoPFTau27L1Seeded
  -> HLT_IsoMu20_eta2p1_LooseChargedIsoPFTauHPS27_eta2p1_CrossL1
</pre>
In the future, it might also be useful to add a way to exclusively select the filters containing a HPS tau, e.g. by defining a bit as
```
    "...*filter('Hps*OverlapFilterIsoEle*PFTau*') + " \
```