### PR TITLE
Add HEEP ID VID bitmap

### DIFF
--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -116,15 +116,23 @@ bitmapVIDForEleSum16.WorkingPoints = cms.vstring(
 )
 _bitmapVIDForEleSum16_docstring = _get_bitmapVIDForEle_docstring(electron_id_modules_WorkingPoints_nanoAOD.modules,bitmapVIDForEleSum16.WorkingPoints)
 
+bitmapVIDForEleHEEP = bitmapVIDForEle.clone()
+bitmapVIDForEleHEEP.WorkingPoints = cms.vstring(
+        "egmGsfElectronIDs:heepElectronID-HEEPV70"
+)
+_bitmapVIDForEleHEEP_docstring = _get_bitmapVIDForEle_docstring(electron_id_modules_WorkingPoints_nanoAOD.modules,bitmapVIDForEleHEEP.WorkingPoints)
+
 
 for modifier in run2_miniAOD_80XLegacy, :
     modifier.toModify(bitmapVIDForEle, src = "slimmedElectronsUpdated")
     modifier.toModify(bitmapVIDForEleSpring15, src = "slimmedElectronsUpdated")
     modifier.toModify(bitmapVIDForEleSum16, src = "slimmedElectronsUpdated")
+    modifier.toModify(bitmapVIDForEleHEEP, src = "slimmedElectronsUpdated")
 for modifier in run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016 ,run2_nanoAOD_102Xv1:
     modifier.toModify(bitmapVIDForEle, src = "slimmedElectronsTo106X")
     modifier.toModify(bitmapVIDForEleSpring15, src = "slimmedElectronsTo106X")
     modifier.toModify(bitmapVIDForEleSum16, src = "slimmedElectronsTo106X")
+    modifier.toModify(bitmapVIDForEleHEEP, src = "slimmedElectronsTo106X")
     
 
 isoForEle = cms.EDProducer("EleIsoValueMapProducer",
@@ -223,6 +231,7 @@ slimmedElectronsWithUserData = cms.EDProducer("PATElectronUserDataEmbedder",
     ),
     userInts = cms.PSet(
         VIDNestedWPBitmap = cms.InputTag("bitmapVIDForEle"),
+        VIDNestedWPBitmapHEEP = cms.InputTag("bitmapVIDForEleHEEP"),
         seedGain = cms.InputTag("seedGainEle"),
     ),
     userCands = cms.PSet(
@@ -379,6 +388,7 @@ electronTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         cutBased = Var("userInt('cutbasedID_Fall17_V2_veto')+userInt('cutbasedID_Fall17_V2_loose')+userInt('cutbasedID_Fall17_V2_medium')+userInt('cutbasedID_Fall17_V2_tight')",int,doc="cut-based ID Fall17 V2 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)"),
         cutBased_Fall17_V1 = Var("userInt('cutbasedID_Fall17_V1_veto')+userInt('cutbasedID_Fall17_V1_loose')+userInt('cutbasedID_Fall17_V1_medium')+userInt('cutbasedID_Fall17_V1_tight')",int,doc="cut-based ID Fall17 V1 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)"),
         vidNestedWPBitmap = Var("userInt('VIDNestedWPBitmap')",int,doc=_bitmapVIDForEle_docstring),
+        vidNestedWPBitmapHEEP = Var("userInt('VIDNestedWPBitmapHEEP')",int,doc=_bitmapVIDForEleHEEP_docstring),
         cutBased_HEEP = Var("userInt('cutbasedID_HEEP')",bool,doc="cut-based HEEP ID"),
         miniPFRelIso_chg = Var("userFloat('miniIsoChg')/pt",float,doc="mini PF relative isolation, charged component"),
         miniPFRelIso_all = Var("userFloat('miniIsoAll')/pt",float,doc="mini PF relative isolation, total (with scaled rho*EA PU corrections)"),
@@ -480,7 +490,7 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     docString = cms.string("MC matching to status==1 electrons or photons"),
 )
 
-electronSequence = cms.Sequence(bitmapVIDForEle + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
+electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
 electronMC = cms.Sequence(electronsMCMatchForTable + electronMCTable)
 from RecoEgamma.ElectronIdentification.heepIdVarValueMapProducer_cfi import heepIDVarValueMaps

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -98,6 +98,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('sip3d', 'sip3d', 20, 0, 20, '3D impact parameter significance wrt first PV, in cm'),
                 Plot1D('tightCharge', 'tightCharge', 3, -0.5, 2.5, 'Tight charge criteria (0:none, 1:isGsfScPixChargeConsistent, 2:isGsfCtfScPixChargeConsistent)'),
                 NoPlot('vidNestedWPBitmap'),
+                NoPlot('vidNestedWPBitmapHEEP'),
             )
         ),
         FatJet = cms.PSet(
@@ -443,6 +444,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('seedGain', 'seedGain', 12, 0.5, 12.5, 'Gain of the seed crystal'),
                 Plot1D('sieie', 'sieie', 20, 0, 0.05, 'sigma_IetaIeta of the supercluster, calculated with full 5x5 region'),
                 NoPlot('vidNestedWPBitmap'),
+                NoPlot('vidNestedWPBitmapHEEP'),
             )
         ),
         Pileup = cms.PSet(


### PR DESCRIPTION
#### PR description:

Adds HEEP VID bitmap for HEEP v7.0, as that is the version used for the already-included pass/fail HEEP ID bit.  Closes #278


#### PR validation:

Produced 1k events MC and verified that the already-included cut-based pass/fail bool always matches the AND of the individual pass/fail cuts extracted from the newly-added bitmask.

For DQM configuration, the updater script looks like it's not doing the correct thing, as the standard VID bitmap is marked as "NoPlot" in the DQM file.  I can add a similar "NoPlot" line for the HEEP VID bitmap manually if needed.