### PR TITLE
Add isolated gen-level photons to the nanoaod

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -205,6 +205,16 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('pt', 'pt', 20, 0, 200, 'pt'),
             )
         ),
+        GenIsolatedPhoton = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Count1D('_size', 10, -0.5, 9.5, 'Isolated photons from Rivet-based ParticleLevelProducer'),
+                Plot1D('eta', 'eta', 20, -7, 7, 'eta'),
+                NoPlot('mass'),
+                Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
+                Plot1D('pt', 'pt', 20, 0, 200, 'pt'),
+            )
+        ),
         GenJet = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -70,6 +70,17 @@ rivetLeptonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     )
 )
 
+rivetPhotonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("particleLevel:photons"),
+    cut = cms.string(""),
+    name= cms.string("GenIsolatedPhoton"),
+    doc = cms.string("Isolated photons from Rivet-based ParticleLevelProducer"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table
+    variables = cms.PSet(
+        P4Vars
+    )
+)
 
 tautagger = cms.EDProducer("GenJetTauTaggerProducer",
     src = rivetLeptonTable.src,
@@ -151,4 +162,4 @@ HTXSCategoryTable = cms.EDProducer("SimpleHTXSFlatTableProducer",
 
 
 particleLevelSequence = cms.Sequence(mergedGenParticles + genParticles2HepMC + particleLevel + tautagger + genParticles2HepMCHiggsVtx + rivetProducerHTXS)
-particleLevelTables = cms.Sequence(rivetLeptonTable + rivetMetTable + HTXSCategoryTable)
+particleLevelTables = cms.Sequence(rivetLeptonTable + rivetPhotonTable + rivetMetTable + HTXSCategoryTable)


### PR DESCRIPTION
#### PR description:

I have added a collection of isolated gen photons to the Rivet particle level producer in CMSSW (https://github.com/cms-sw/cmssw/pull/28371), and I want to also add it to the NANOAODSIM. This is useful for reporting cross sections with photons in the final state.

#### PR validation:

I have run over a recent ttbar relval sample and found that this pull request increases the size of the nanoaod by around 0.025%.
