### PR TITLE
add nb and nc hadrons on fatjets and SD subjets

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -455,6 +455,9 @@ fatJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 		     doc="index of first subjet"),
         subJetIdx2 = Var("?nSubjetCollections()>0 && subjets('SoftDropPuppi').size()>1?subjets('SoftDropPuppi')[1].key():-1", int,
 		     doc="index of second subjet"),
+        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", int, doc="number of b-hadrons",precision=10),
+        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", int, doc="number of c-hadrons",precision=10),
+
 
 #        btagDeepC = Var("bDiscriminator('pfDeepCSVJetTags:probc')",float,doc="CMVA V2 btag discriminator",precision=10),
 #puIdDisc = Var("userFloat('pileupJetId:fullDiscriminant')",float,doc="Pilup ID discriminant",precision=10),
@@ -499,6 +502,8 @@ subJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         tau4 = Var("userFloat('NjettinessAK8Subjets:tau4')",float, doc="Nsubjettiness (4 axis)",precision=10),
         n2b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN2')", float, doc="N2 with beta=1", precision=10),
         n3b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN3')", float, doc="N3 with beta=1", precision=10),
+        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", int, doc="number of b-hadrons",precision=10),
+        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", int, doc="number of c-hadrons",precision=10),
     )
 )
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -455,8 +455,8 @@ fatJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 		     doc="index of first subjet"),
         subJetIdx2 = Var("?nSubjetCollections()>0 && subjets('SoftDropPuppi').size()>1?subjets('SoftDropPuppi')[1].key():-1", int,
 		     doc="index of second subjet"),
-        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", int, doc="number of b-hadrons",precision=10),
-        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", int, doc="number of c-hadrons",precision=10),
+        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", uint8, doc="number of b-hadrons"),
+        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", uint8, doc="number of c-hadrons"),
 
 
 #        btagDeepC = Var("bDiscriminator('pfDeepCSVJetTags:probc')",float,doc="CMVA V2 btag discriminator",precision=10),
@@ -502,8 +502,8 @@ subJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         tau4 = Var("userFloat('NjettinessAK8Subjets:tau4')",float, doc="Nsubjettiness (4 axis)",precision=10),
         n2b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN2')", float, doc="N2 with beta=1", precision=10),
         n3b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN3')", float, doc="N3 with beta=1", precision=10),
-        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", int, doc="number of b-hadrons",precision=10),
-        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", int, doc="number of c-hadrons",precision=10),
+        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", uint8, doc="number of b-hadrons"),
+        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", uint8, doc="number of c-hadrons"),
     )
 )
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -455,8 +455,8 @@ fatJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 		     doc="index of first subjet"),
         subJetIdx2 = Var("?nSubjetCollections()>0 && subjets('SoftDropPuppi').size()>1?subjets('SoftDropPuppi')[1].key():-1", int,
 		     doc="index of second subjet"),
-        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", int, doc="number of b-hadrons",precision=10),
-        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", int, doc="number of c-hadrons",precision=10),
+        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", "uint8", doc="number of b-hadrons"),
+        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", "uint8", doc="number of c-hadrons"),
 
 
 #        btagDeepC = Var("bDiscriminator('pfDeepCSVJetTags:probc')",float,doc="CMVA V2 btag discriminator",precision=10),
@@ -502,8 +502,8 @@ subJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         tau4 = Var("userFloat('NjettinessAK8Subjets:tau4')",float, doc="Nsubjettiness (4 axis)",precision=10),
         n2b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN2')", float, doc="N2 with beta=1", precision=10),
         n3b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN3')", float, doc="N3 with beta=1", precision=10),
-        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", int, doc="number of b-hadrons",precision=10),
-        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", int, doc="number of c-hadrons",precision=10),
+        nBHadrons=Var("jetFlavourInfo().getbHadrons().size()", "uint8", doc="number of b-hadrons"),
+        nCHadrons=Var("jetFlavourInfo().getcHadrons().size()", "uint8", doc="number of c-hadrons"),
     )
 )
 


### PR DESCRIPTION
#### PR description:

Adds the number of B and C hadrons in AK8 jets and for each subjet returned by the softdrop algorithms. These variables are necessary for both the calibration of the taggers and the analyses using these tagger in order to apply the scale factors. 

#### PR validation:

PR validated using the runtests.sh in the nanoAOD package [MC: RelValTTbar] and in data using the sample: Run2017D/JetHT/MINIAOD/31Mar2018-v1/
