### PR TITLE
Correctly fill trigger bits for disappeared paths

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.cc
@@ -15,7 +15,8 @@ void TriggerOutputBranches::updateTriggerNames(TTree& tree,
   }
 
   for (auto& existing : m_triggerBranches) {
-    existing.idx = -1;  // reset all triggers as not found
+    existing.idx = -1;    // reset all triggers as not found and zero buffer
+    existing.buffer = 0;  // reset all triggers as not found and zero buffer
     for (unsigned int j = 0; j < newNames.size(); j++) {
       std::string name = newNames[j];  // no const & as it will be modified below!
       std::size_t vfound = name.rfind("_v");

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.h
@@ -37,7 +37,7 @@ private:
     TBranch *branch;
     uint8_t buffer;
     NamedBranchPtr(const std::string &aname, const std::string &atitle, TBranch *branchptr = nullptr)
-        : name(aname), title(atitle), branch(branchptr), buffer(-1) {}
+        : name(aname), title(atitle), branch(branchptr), buffer(0) {}
   };
   std::vector<NamedBranchPtr> m_triggerBranches;
   long m_lastRun;
@@ -45,8 +45,7 @@ private:
 
   template <typename T>
   void fillColumn(NamedBranchPtr &nb, const edm::TriggerResults &triggers) {
-    if (nb.idx >= 0)
-      nb.buffer = triggers.accept(nb.idx);
+    nb.buffer = (nb.idx >= 0) ? triggers.accept(nb.idx) : 0;
     nb.branch->SetAddress(&(nb.buffer));  // Can be improved: this is not reallt needed at each event
         //but we should be sure that resize of vectors of TriggerOutputBranches do not mess up things
   }


### PR DESCRIPTION
This patch fixes a bug in how the trigger bit information is filled for paths that are not anymore present in the stream of events, when crossing a run boundary.
Previously they would continue being filled with the last value seen, now they will be set to zero.

Also taken the chance to initialize the buffer value to zero, coherently with the default backfill value changed a while ago.

Fixing #471 @ktht