### PR TITLE
add puppijets

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -230,6 +230,18 @@ jetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     )
 )
 
+puppiJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("slimmedJetsPuppi"),
+    cut = cms.string(""), #we should not filter on cross linked collections
+    name = cms.string("PuppiJet"),
+    doc  = cms.string("slimmedJetsPuppi, i.e. ak4 Puppi PFJets CHS with JECs applied, after basic selection (" + finalJets.cut.value()+")"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table for the jets
+    variables = cms.PSet(P4Vars,
+        rawFactor = Var("1.-jecFactor('Uncorrected')",float,doc="1 - Factor to get back to raw pT",precision=-1),
+    )
+)
+
 #jets are not as precise as muons
 jetTable.variables.pt.precision=10
 
@@ -530,8 +542,6 @@ corrT1METJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     )
 )
 
-
-
 ## MC STUFF ######################
 jetMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("linkedObjects","jets"),
@@ -662,7 +672,7 @@ _jetSequence_2016.insert(_jetSequence_2016.index(tightJetIdAK8), looseJetIdAK8)
 run2_jme_2016.toReplaceWith(jetSequence, _jetSequence_2016)
 
 #after cross linkining
-jetTables = cms.Sequence(bjetMVA+bjetNN+cjetNN+jetTable+fatJetTable+subJetTable+saJetTable+saTable)
+jetTables = cms.Sequence(bjetMVA+bjetNN+cjetNN+jetTable+fatJetTable+subJetTable+saJetTable+saTable+puppiJetTable)
 
 #MC only producers and tables
 jetMC = cms.Sequence(jetMCTable+genJetTable+patJetPartons+genJetFlavourTable+genJetAK8Table+genJetAK8FlavourAssociation+genJetAK8FlavourTable+fatJetMCTable+genSubJetAK8Table+subjetMCTable)

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -19,10 +19,8 @@ metTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
        significance = Var("metSignificance()", float, doc="MET significance",precision=10),
        MetUnclustEnUpDeltaX = Var("shiftedPx('UnclusteredEnUp')-px()", float, doc="Delta (METx_mod-METx) Unclustered Energy Up",precision=10),
        MetUnclustEnUpDeltaY = Var("shiftedPy('UnclusteredEnUp')-py()", float, doc="Delta (METy_mod-METy) Unclustered Energy Up",precision=10),
-
     ),
 )
-
 
 rawMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = metTable.src,
@@ -36,7 +34,6 @@ rawMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
        sumEt = Var("uncorSumEt", float, doc="scalar sum of Et", precision=10),
     ),
 )
-
 
 caloMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = metTable.src,
@@ -59,6 +56,8 @@ puppiMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     extension = cms.bool(False), # this is the main table for the MET
     variables = cms.PSet(PTVars,
        sumEt = Var("sumEt()", float, doc="scalar sum of Et",precision=10),
+       MetUnclustEnUpDeltaX = Var("shiftedPx('UnclusteredEnUp')-px()", float, doc="Delta (METx_mod-METx) Unclustered Energy Up",precision=10),
+       MetUnclustEnUpDeltaY = Var("shiftedPy('UnclusteredEnUp')-py()", float, doc="Delta (METy_mod-METy) Unclustered Energy Up",precision=10),
     ),
 )
 
@@ -106,6 +105,10 @@ metFixEE2017Table.src = cms.InputTag("slimmedMETsFixEE2017")
 metFixEE2017Table.name = cms.string("METFixEE2017")
 metFixEE2017Table.doc = cms.string("Type-1 corrected PF MET, with fixEE2017 definition")
 
+puppiMetFixEE2017Table = puppiMetTable.clone()
+puppiMetFixEE2017Table.src = cms.InputTag("slimmedMETsPuppiFixEE2017")
+puppiMetFixEE2017Table.name = cms.string("PuppiMETFixEE2017")
+puppiMetFixEE2017Table.doc = cms.string("Type-1 corrected PF Puppi MET, with fixEE2017 definition")
 
 metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = metTable.src,
@@ -122,7 +125,7 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 metTables = cms.Sequence( metTable + rawMetTable + caloMetTable + puppiMetTable + rawPuppiMetTable+ tkMetTable + chsMetTable)
-_withFixEE2017_sequence = cms.Sequence(metTables.copy() + metFixEE2017Table)
+_withFixEE2017_sequence = cms.Sequence(metTables.copy() + metFixEE2017Table + puppiMetFixEE2017Table)
 for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
     modifier.toReplaceWith(metTables,_withFixEE2017_sequence) # only in old miniAOD, the new ones will come from the UL rereco
 metMC = cms.Sequence( metMCTable )

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -179,7 +179,7 @@ def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
     return process
 
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
-#from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
+from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
 def nanoAOD_recalibrateMETs(process,isData):
     runMetCorAndUncFromMiniAOD(process,isData=isData)
     process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.fullPatMetSequence))
@@ -197,10 +197,10 @@ def nanoAOD_recalibrateMETs(process,isData):
         table.variables.muonSubtrFactor = Var("1-userFloat('muonSubtrRawPt')/(pt()*jecFactor('Uncorrected'))",float,doc="1-(muon-subtracted raw pt)/(raw pt)",precision=6)
     process.metTables += process.corrT1METJetTable
 #    makePuppiesFromMiniAOD(process,True) # call this before in the global customizer otherwise it would reset photon IDs in VID
-#    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi")
-#    process.puppiNoLep.useExistingWeights = False
-#    process.puppi.useExistingWeights = False
-#    process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))
+    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi")
+    process.puppiNoLep.useExistingWeights = False
+    process.puppi.useExistingWeights = False
+    process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))
     return process
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
@@ -218,7 +218,7 @@ def nanoAOD_activateVID(process):
         
  
 
-    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD) # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
+#    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD) # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
     for modname in photon_id_modules_WorkingPoints_nanoAOD.modules:
         setupAllVIDIdsInModule(process,modname,setupVIDPhotonSelection)
     process.photonSequence.insert(process.photonSequence.index(bitmapVIDForPho),process.egmPhotonIDSequence)
@@ -265,10 +265,12 @@ def nanoAOD_runMETfixEE2017(process,isData):
                                fixEE2017 = True,
                                fixEE2017Params = {'userawPt': True, 'ptThreshold':50.0, 'minEtaThreshold':2.65, 'maxEtaThreshold': 3.139},
                                postfix = "FixEE2017")
+    runMetCorAndUncFromMiniAOD(process,isData=isData,fixEE2017 = True,fixEE2017Params = {'userawPt': True, 'ptThreshold':50.0, 'minEtaThreshold':2.65, 'maxEtaThreshold': 3.139},postfix = "PuppiFixEE2017",metType="Puppi",jetFlavor="AK4PFPuppi",pfCandColl=cms.InputTag("puppiForMET"),recoMetFromPFCs=True)
     process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(jetSequence),process.fullPatMetSequenceFixEE2017)
+    process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(jetSequence),process.fullPatMetSequencePuppiFixEE2017)
 
 def nanoAOD_customizeCommon(process):
-#    makePuppiesFromMiniAOD(process,True) # call this here as it calls switchOnVIDPhotonIdProducer
+    makePuppiesFromMiniAOD(process,True) # call this here as it calls switchOnVIDPhotonIdProducer
     process = nanoAOD_activateVID(process)
     nanoAOD_addDeepInfo_switch = cms.PSet(
         nanoAOD_addDeepBTag_switch = cms.untracked.bool(False),


### PR DESCRIPTION
#### PR description:

Related to https://github.com/cms-nanoAOD/cmssw/pull/467, I realized that in order to recalculate the PuppiMET, we also need the PuppiJets, so I have added them in this pull request. I have also added the  unclustered energy ups, which are also used in the MET recalculation. Finally, I have added the FixEE2017 version of PuppiMET. A "CorrT1METPuppiJet" collection would be empty because there are no PuppiJets with pt < 20 GeV in the MINIAOD.

#### PR validation:

Yes, I have checked that this pull request runs on some 2016 and 2017 samples, and the expected information is stored. 

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
