### PR TITLE
Add puppimet uncertainties

### DIFF
--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -59,6 +59,10 @@ puppiMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     extension = cms.bool(False), # this is the main table for the MET
     variables = cms.PSet(PTVars,
        sumEt = Var("sumEt()", float, doc="scalar sum of Et",precision=10),
+       ptJERUp = Var("shiftedPt('JetResUp')", float, doc="",precision=10),
+       phiJERUp = Var("shiftedPhi('JetResUp')", float, doc="",precision=10),
+       ptJESUp = Var("shiftedPt('JetEnUp')", float, doc="",precision=10),
+       phiJESUp = Var("shiftedPhi('JetEnUp')", float, doc="",precision=10),
     ),
 )
 

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -59,10 +59,10 @@ puppiMetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     extension = cms.bool(False), # this is the main table for the MET
     variables = cms.PSet(PTVars,
        sumEt = Var("sumEt()", float, doc="scalar sum of Et",precision=10),
-       ptJERUp = Var("shiftedPt('JetResUp')", float, doc="",precision=10),
-       phiJERUp = Var("shiftedPhi('JetResUp')", float, doc="",precision=10),
-       ptJESUp = Var("shiftedPt('JetEnUp')", float, doc="",precision=10),
-       phiJESUp = Var("shiftedPhi('JetEnUp')", float, doc="",precision=10),
+       ptJERUp = Var("shiftedPt('JetResUp')", float, doc="JER up pt",precision=10),
+       phiJERUp = Var("shiftedPhi('JetResUp')", float, doc="JER up phi",precision=10),
+       ptJESUp = Var("shiftedPt('JetEnUp')", float, doc="JES up pt",precision=10),
+       phiJESUp = Var("shiftedPhi('JetEnUp')", float, doc="JES up phi",precision=10),
     ),
 )
 

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -481,7 +481,11 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
             sels = cms.PSet(),
             plots = cms.VPSet(
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
+                Plot1D('phiJERUp', 'phiJERUp', 20, -3.14159, 3.14159, 'JER up phi'),
+                Plot1D('phiJESUp', 'phiJESUp', 20, -3.14159, 3.14159, 'JES up phi'),
                 Plot1D('pt', 'pt', 20, 0, 400, 'pt'),
+                Plot1D('ptJERUp', 'ptJERUp', 20, 0, 400, 'JER up pt'),
+                Plot1D('ptJESUp', 'ptJESUp', 20, 0, 400, 'JES up pt'),
                 Plot1D('sumEt', 'sumEt', 20, 200, 3000, 'scalar sum of Et'),
             )
         ),


### PR DESCRIPTION
#### PR description:

As discussed in https://github.com/cms-nanoAOD/cmssw/pull/474, we are adding the JES and JER uncertainties to PuppiMET (more specifically 4 variables: ptJERUp, phiJERUp, ptJESUp, phiJESUp).

@peruzzim, you may want to unmerge the pull request https://github.com/cms-nanoAOD/cmssw/pull/467, that was intended to calculate the variables I am storing here

#### PR validation:

Yes, I have checked that this pull request runs on some 2016 and 2017 samples, and the expected information is stored.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
