### PR TITLE
Dimuon vertex constructor

### DIFF
--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -226,7 +226,7 @@ namespace Rivet {
           if (top.genParticle()->end_vertex())
             for (auto child : top.children())
               if (PID::isW(child.pid()))
-                Ws += child;
+                Ws += getLastInstance(child);
         }
       }
 

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -63,9 +63,11 @@ namespace Rivet {
 
     /// @brief Checks whether the input particle has a child with a given PDGID
     bool hasChild(const ConstGenParticlePtr &ptcl, int pdgID) {
-      for (auto child : Particle(*ptcl).children())
-        if (child.pid() == pdgID)
+      for (auto child : Particle(*ptcl).children()) {
+        if (child.pid() == pdgID) {
           return true;
+        }
+      }
       return false;
     }
 
@@ -79,17 +81,21 @@ namespace Rivet {
 
     /// @brief Return true is particle decays to quarks
     bool quarkDecay(const Particle &p) {
-      for (auto child : p.children())
-        if (PID::isQuark(child.pid()))
+      for (auto child : p.children()) {
+        if (PID::isQuark(child.pid())) {
           return true;
+        }
+      }
       return false;
     }
 
     /// @brief Return true if particle decays to charged leptons.
     bool ChLeptonDecay(const Particle &p) {
-      for (auto child : p.children())
-        if (PID::isChLepton(child.pid()))
+      for (auto child : p.children()) {
+        if (PID::isChLepton(child.pid())) {
           return true;
+        }
+      }
       return false;
     }
 

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -760,7 +760,7 @@ namespace Rivet {
         else if (V.pt()<150) return QQ2HLNU_PTV_75_150;
       	else if (V.pt()>250) return QQ2HLNU_PTV_GT250;
       	// 150 < pTV/GeV < 250
-      	return jets.size()==0 ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
+      	return jets.empty() ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
       }
       // 4. qq->ZH->llH categories
       else if (prodMode==HTXS::QQ2ZH) {
@@ -769,7 +769,7 @@ namespace Rivet {
         else if (V.pt()<150) return QQ2HLL_PTV_75_150;
       	else if (V.pt()>250) return QQ2HLL_PTV_GT250;
       	// 150 < pTV/GeV < 250
-      	return jets.size()==0 ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
+      	return jets.empty() ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
       }
       // 5. gg->ZH->llH categories
       else if (prodMode==HTXS::GG2ZH ) {
@@ -777,7 +777,7 @@ namespace Rivet {
         else if (V.pt()<75) return GG2HLL_PTV_0_75;
         else if (V.pt()<150) return GG2HLL_PTV_75_150;
         else if (V.pt()>250) return GG2HLL_PTV_GT250;
-        return jets.size()==0 ? GG2HLL_PTV_150_250_0J : GG2HLL_PTV_150_250_GE1J;
+        return jets.empty() ? GG2HLL_PTV_150_250_0J : GG2HLL_PTV_150_250_GE1J;
       }
       // 6.ttH,bbH,tH categories
       else if (prodMode==HTXS::TTH) {

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -85,6 +85,14 @@ namespace Rivet {
       return false;
     }
 
+    /// @brief Return true if particle decays to charged leptons.
+    bool ChLeptonDecay(const Particle &p) {
+      for (auto child:p.children())
+        if (PID::isChLepton(child.pid())) return true;
+      return false;
+    }
+
+
     /// @brief Returns the classification object with the error code set.
     ///        Prints an warning message, and keeps track of number of errors
     HiggsClassification error(HiggsClassification &cat,
@@ -120,6 +128,11 @@ namespace Rivet {
       cat.stage1_1_cat_pTjet30GeV = HTXS::Stage1_1::UNKNOWN;
       cat.stage1_1_fine_cat_pTjet25GeV = HTXS::Stage1_1_Fine::UNKNOWN;
       cat.stage1_1_fine_cat_pTjet30GeV = HTXS::Stage1_1_Fine::UNKNOWN;
+      cat.stage1_2_cat_pTjet25GeV = HTXS::Stage1_2::UNKNOWN;
+      cat.stage1_2_cat_pTjet30GeV = HTXS::Stage1_2::UNKNOWN;
+      cat.stage1_2_fine_cat_pTjet25GeV = HTXS::Stage1_2_Fine::UNKNOWN;
+      cat.stage1_2_fine_cat_pTjet30GeV = HTXS::Stage1_2_Fine::UNKNOWN;
+
 
       if (prodMode == HTXS::UNKNOWN)
         return error(cat,
@@ -302,6 +315,8 @@ namespace Rivet {
        */
 
       // Apply the categorization categorization
+      cat.isZ2vvDecay = false;
+      if( (prodMode==HTXS::GG2ZH || prodMode==HTXS::QQ2ZH) && !quarkDecay(cat.V) && !ChLeptonDecay(cat.V) ) cat.isZ2vvDecay = true;
       cat.stage0_cat = getStage0Category(prodMode, cat.higgs, cat.V);
       cat.stage1_cat_pTjet25GeV = getStage1Category(prodMode, cat.higgs, cat.jets25, cat.V);
       cat.stage1_cat_pTjet30GeV = getStage1Category(prodMode, cat.higgs, cat.jets30, cat.V);
@@ -309,6 +324,11 @@ namespace Rivet {
       cat.stage1_1_cat_pTjet30GeV = getStage1_1_Category(prodMode, cat.higgs, cat.jets30, cat.V);
       cat.stage1_1_fine_cat_pTjet25GeV = getStage1_1_Fine_Category(prodMode, cat.higgs, cat.jets25, cat.V);
       cat.stage1_1_fine_cat_pTjet30GeV = getStage1_1_Fine_Category(prodMode, cat.higgs, cat.jets30, cat.V);
+      cat.stage1_2_cat_pTjet25GeV = getStage1_2_Category(prodMode,cat.higgs,cat.jets25,cat.V);
+      cat.stage1_2_cat_pTjet30GeV = getStage1_2_Category(prodMode,cat.higgs,cat.jets30,cat.V);
+      cat.stage1_2_fine_cat_pTjet25GeV = getStage1_2_Fine_Category(prodMode,cat.higgs,cat.jets25,cat.V);
+      cat.stage1_2_fine_cat_pTjet30GeV = getStage1_2_Fine_Category(prodMode,cat.higgs,cat.jets30,cat.V);
+
 
       cat.errorCode = HTXS::SUCCESS;
       ++m_errorCount[HTXS::SUCCESS];
@@ -359,6 +379,24 @@ namespace Rivet {
         return 0;
     }
 
+    /// @brief VBF topology selection Stage1.2
+    /// 0 = fail loose selection: m_jj > 350 GeV
+    /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
+    /// 3 pass tight (m_jj>700 GeV), but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
+    int vbfTopology_Stage1_2(const Jets &jets, const Particle &higgs) {
+      if (jets.size() < 2)
+        return 0;
+      const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
+      double mjj = (j1 + j2).mass();
+      if (mjj > 350 && mjj <= 700)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 1 : 2;
+      else if (mjj > 700)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 3 : 4;
+      else
+        return 0;
+    }
+
+
     /// @brief VBF topology selection for Stage1.1 Fine
     /// 0 = fail loose selection: m_jj > 350 GeV
     /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
@@ -381,6 +419,23 @@ namespace Rivet {
       else
         return 0;
     }
+    /// @brief VBF topology selection for Stage1_2
+    /// 0 = fail loose selection: m_jj > 350 GeV
+    /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
+    /// 3 pass 700<m_jj<1000 GeV, but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
+    /// 5 pass 1000<m_jj<1500 GeV, but fail additional cut pT(Hjj)<25. 6 pass pT(Hjj)>25 selection
+    /// 7 pass m_jj>1500 GeV, but fail additional cut pT(Hjj)<25. 8 pass pT(Hjj)>25 selection
+    int vbfTopology_Stage1_2_Fine(const Jets &jets, const Particle &higgs) {
+      if (jets.size()<2) return 0;
+      const FourMomentum &j1=jets[0].momentum(), &j2=jets[1].momentum();
+      double mjj = (j1+j2).mass();
+      if(mjj>350 && mjj<=700) return (j1+j2+higgs.momentum()).pt()<25 ? 1 : 2;
+      else if(mjj>700 && mjj<=1000) return (j1+j2+higgs.momentum()).pt()<25 ? 3 : 4;
+      else if(mjj>1000 && mjj<=1500) return (j1+j2+higgs.momentum()).pt()<25 ? 5 : 6;
+      else if(mjj>1500) return (j1+j2+higgs.momentum()).pt()<25 ? 7 : 8;
+      else return 0;
+    }
+
 
     /// @brief Whether the Higgs is produced in association with a vector boson (VH)
     bool isVH(HTXS::HiggsProdMode p) { return p == HTXS::WH || p == HTXS::QQ2ZH || p == HTXS::GG2ZH; }
@@ -694,6 +749,172 @@ namespace Rivet {
       return UNKNOWN;
     }
 
+    /// @brief Stage-1.2 categorization
+    HTXS::Stage1_2::Category getStage1_2_Category(const HTXS::HiggsProdMode prodMode,
+					     const Particle &higgs,
+					     const Jets &jets,
+					     const Particle &V) {
+      using namespace HTXS::Stage1_2;
+      int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology(jets,higgs);
+
+      // 1. GGF Stage 1 categories
+      //    Following YR4 write-up: XXXXX
+      if (prodMode==HTXS::GGF || (prodMode==HTXS::GG2ZH && quarkDecay(V)) ) {
+    if (fwdHiggs)        return GG2H_FWDH;
+    if ( higgs.pt()>200 ) return Category(GG2H_PTH_200_300+getBin(higgs.pt(),{200,300,450,650}));
+    if (Njets==0)  return higgs.pt()<10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
+    if (Njets==1)  return Category(GG2H_1J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
+    if (Njets>1){
+        //VBF topology
+        if(vbfTopo) return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25+vbfTopo-1);
+        //Njets >= 2jets without VBF topology (mjj<350)
+        return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
+      }
+    }
+
+      // 2. Electroweak qq->Hqq Stage 1.2 categories
+      else if (prodMode==HTXS::VBF || ( isVH(prodMode) && quarkDecay(V)) ) {
+    if (std::abs(higgs.rapidity())>2.5) return QQ2HQQ_FWDH;
+    int Njets=jets.size();
+    if (Njets==0)        return QQ2HQQ_0J;
+    else if (Njets==1)   return QQ2HQQ_1J;
+    else if (Njets>=2) {
+        double mjj = (jets[0].mom()+jets[1].mom()).mass();
+        if ( mjj < 60 )      return QQ2HQQ_GE2J_MJJ_0_60;
+        else if ( 60 < mjj && mjj < 120 ) return QQ2HQQ_GE2J_MJJ_60_120;
+        else if ( 120 < mjj && mjj < 350 ) return QQ2HQQ_GE2J_MJJ_120_350;
+        else if (  mjj > 350 ) {
+            if (higgs.pt()>200) return QQ2HQQ_GE2J_MJJ_GT350_PTH_GT200;
+            if(vbfTopo) return Category(QQ2HQQ_GE2J_MJJ_GT350_PTH_GT200+vbfTopo);
+        }
+    }
+      }
+      // 3. WH->Hlv categories
+      else if (prodMode==HTXS::WH) {
+        if (fwdHiggs) return QQ2HLNU_FWDH;
+        else if (V.pt()<75) return QQ2HLNU_PTV_0_75;
+        else if (V.pt()<150) return QQ2HLNU_PTV_75_150;
+      	else if (V.pt()>250) return QQ2HLNU_PTV_GT250;
+      	// 150 < pTV/GeV < 250
+      	return jets.size()==0 ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
+      }
+      // 4. qq->ZH->llH categories
+      else if (prodMode==HTXS::QQ2ZH) {
+        if (fwdHiggs) return QQ2HLL_FWDH;
+        else if (V.pt()<75) return QQ2HLL_PTV_0_75;
+        else if (V.pt()<150) return QQ2HLL_PTV_75_150;
+      	else if (V.pt()>250) return QQ2HLL_PTV_GT250;
+      	// 150 < pTV/GeV < 250
+      	return jets.size()==0 ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
+      }
+      // 5. gg->ZH->llH categories
+      else if (prodMode==HTXS::GG2ZH ) {
+        if (fwdHiggs) return GG2HLL_FWDH;
+        else if (V.pt()<75) return GG2HLL_PTV_0_75;
+        else if (V.pt()<150) return GG2HLL_PTV_75_150;
+        else if (V.pt()>250) return GG2HLL_PTV_GT250;
+        return jets.size()==0 ? GG2HLL_PTV_150_250_0J : GG2HLL_PTV_150_250_GE1J;
+      }
+      // 6.ttH,bbH,tH categories
+      else if (prodMode==HTXS::TTH) {
+        if (fwdHiggs) return TTH_FWDH;
+        else return Category(TTH_PTH_0_60+getBin(higgs.pt(),{0,60,120,200,300}));
+      }
+      else if (prodMode==HTXS::BBH) return Category(BBH_FWDH+ctrlHiggs);
+      else if (prodMode==HTXS::TH ) return Category(TH_FWDH+ctrlHiggs);
+      return UNKNOWN;
+    }
+
+    /// @brief Stage-1.2 Fine categorization
+    HTXS::Stage1_2_Fine::Category getStage1_2_Fine_Category(const HTXS::HiggsProdMode prodMode,
+                         const Particle &higgs,
+                         const Jets &jets,
+                         const Particle &V) {
+      using namespace HTXS::Stage1_2_Fine;
+      int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology_Stage1_2_Fine(jets,higgs);
+
+      // 1. GGF Stage 1.2 categories
+      //    Following YR4 write-up: XXXXX
+      if (prodMode==HTXS::GGF || (prodMode==HTXS::GG2ZH && quarkDecay(V)) ) {
+    if (fwdHiggs)        return GG2H_FWDH;
+    if ( higgs.pt()>200 ){
+      if (Njets>0){
+        double pTHj = (jets[0].momentum()+higgs.momentum()).pt();
+        if( pTHj/higgs.pt()>0.15 ) return Category(GG2H_PTH_200_300_PTHJoverPTH_GT15+getBin(higgs.pt(),{200,300,450,650}));
+        else return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15+getBin(higgs.pt(),{200,300,450,650}));
+      }
+      else return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15+getBin(higgs.pt(),{200,300,450,650}));
+    }
+    if (Njets==0)  return higgs.pt()<10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
+    if (Njets==1)  return Category(GG2H_1J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
+    if (Njets>1){
+        //double mjj = (jets[0].mom()+jets[1].mom()).mass();
+        double pTHjj = (jets[0].momentum()+jets[1].momentum()+higgs.momentum()).pt();
+        //VBF topology
+        if(vbfTopo) return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25+vbfTopo-1);
+        //Njets >= 2jets without VBF topology (mjj<350)
+        if (pTHjj<25) return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_0_25+getBin(higgs.pt(),{0,60,120,200}));
+        else return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_GT25+getBin(higgs.pt(),{0,60,120,200}));
+    }
+      }
+
+      // 2. Electroweak qq->Hqq Stage 1.2 categories
+      else if (prodMode==HTXS::VBF || ( isVH(prodMode) && quarkDecay(V)) ) {
+    if (std::abs(higgs.rapidity())>2.5) return QQ2HQQ_FWDH;
+    int Njets=jets.size();
+    if (Njets==0)        return QQ2HQQ_0J;
+    else if (Njets==1)   return QQ2HQQ_1J;
+    else if (Njets>=2) {
+        double mjj = (jets[0].mom()+jets[1].mom()).mass();
+        double pTHjj = (jets[0].momentum()+jets[1].momentum()+higgs.momentum()).pt();
+        if (mjj<350){
+            if (pTHjj<25) return Category(QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_0_25+getBin(mjj,{0,60,120,350}));
+            else return Category(QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_GT25+getBin(mjj,{0,60,120,350}));
+        } else { //mjj>350 GeV
+            if (higgs.pt()<200){
+                return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25+vbfTopo-1);
+            } else {
+                return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_GT200_PTHJJ_0_25+vbfTopo-1);
+            }
+        }
+    }
+      }
+      // 3. WH->Hlv categories
+      else if (prodMode==HTXS::WH) {
+        if (fwdHiggs) return QQ2HLNU_FWDH;
+        int Njets=jets.size();
+        if (Njets==0) return Category(QQ2HLNU_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
+        if (Njets==1) return Category(QQ2HLNU_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
+        return Category(QQ2HLNU_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      }
+      // 4. qq->ZH->llH categories
+      else if (prodMode==HTXS::QQ2ZH) {
+        if (fwdHiggs) return QQ2HLL_FWDH;
+        int Njets=jets.size();
+        if (Njets==0) return Category(QQ2HLL_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
+        if (Njets==1) return Category(QQ2HLL_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
+        return Category(QQ2HLL_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      }
+      // 5. gg->ZH->llH categories
+      else if (prodMode==HTXS::GG2ZH ) {
+        if (fwdHiggs) return GG2HLL_FWDH;
+        int Njets=jets.size();
+        if (Njets==0) return Category(GG2HLL_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
+        if (Njets==1) return Category(GG2HLL_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
+        return Category(GG2HLL_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      }
+      // 6.ttH,bbH,tH categories
+      else if (prodMode==HTXS::TTH) {
+        if (fwdHiggs) return TTH_FWDH;
+        else return Category(TTH_PTH_0_60+getBin(higgs.pt(),{0,60,120,200,300,450}));
+      }
+      else if (prodMode==HTXS::BBH) return Category(BBH_FWDH+ctrlHiggs);
+      else if (prodMode==HTXS::TH ) return Category(TH_FWDH+ctrlHiggs);
+      return UNKNOWN;
+    }
+
     /// @}
 
     /// @name Default Rivet analysis methods and steering methods
@@ -769,6 +990,18 @@ namespace Rivet {
       hist_stage1_pTjet25->fill(cat.stage1_cat_pTjet25GeV % 100 + off, weight);
       hist_stage1_pTjet30->fill(cat.stage1_cat_pTjet30GeV % 100 + off, weight);
 
+      // Stage 1_2 enum offsets for each production mode: GGF=17, VBF=11, WH= 6, QQ2ZH=6, GG2ZH=6, TTH=6, BBH=2, TH=2
+      static vector<int> offset1_2({0,1,18,29,35,41,47,53,55,57}); 
+      int off1_2 = offset1_2[P];
+      // Stage 1_2 Fine enum offsets for each production mode: GGF=28, VBF=25, WH= 16, QQ2ZH=16, GG2ZH=16, TTH=7, BBH=2, TH=2
+      static vector<int> offset1_2f({0,1,29,54,70,86,102,109,111,113});
+      int off1_2f = offset1_2f[P];
+      hist_stage1_2_pTjet25->fill(cat.stage1_2_cat_pTjet25GeV%100 + off1_2, weight);
+      hist_stage1_2_pTjet30->fill(cat.stage1_2_cat_pTjet30GeV%100 + off1_2, weight);
+      hist_stage1_2_fine_pTjet25->fill(cat.stage1_2_fine_cat_pTjet25GeV%100 + off1_2f, weight);
+      hist_stage1_2_fine_pTjet30->fill(cat.stage1_2_fine_cat_pTjet30GeV%100 + off1_2f, weight);
+
+
       // Fill histograms: variables used in the categorization
       hist_pT_Higgs->fill(cat.higgs.pT(), weight);
       hist_y_Higgs->fill(cat.higgs.rapidity(), weight);
@@ -776,6 +1009,8 @@ namespace Rivet {
 
       hist_Njets25->fill(cat.jets25.size(), weight);
       hist_Njets30->fill(cat.jets30.size(), weight);
+
+      hist_isZ2vv->fill(cat.isZ2vvDecay, weight);
 
       // Jet variables. Use jet collection with pT threshold at 30 GeV
       if (!cat.jets30.empty())
@@ -819,6 +1054,10 @@ namespace Rivet {
       for (auto hist : {hist_stage0,
                         hist_stage1_pTjet25,
                         hist_stage1_pTjet30,
+                        hist_stage1_2_pTjet25,
+                        hist_stage1_2_pTjet30,
+                        hist_stage1_2_fine_pTjet25,
+                        hist_stage1_2_fine_pTjet30,
                         hist_Njets25,
                         hist_Njets30,
                         hist_pT_Higgs,
@@ -839,6 +1078,10 @@ namespace Rivet {
       book(hist_stage0, "HTXS_stage0", 20, 0, 20);
       book(hist_stage1_pTjet25, "HTXS_stage1_pTjet25", 40, 0, 40);
       book(hist_stage1_pTjet30, "HTXS_stage1_pTjet30", 40, 0, 40);
+      book(hist_stage1_2_pTjet25, "HTXS_stage1_2_pTjet25",57,0,57);
+      book(hist_stage1_2_pTjet30, "HTXS_stage1_2_pTjet30",57,0,57);
+      book(hist_stage1_2_pTjet25, "HTXS_stage1_2_fine_pTjet25",113,0,113);
+      book(hist_stage1_2_fine_pTjet30, "HTXS_stage1_2_fine_pTjet30",113,0,113);
       book(hist_pT_Higgs, "pT_Higgs", 80, 0, 400);
       book(hist_y_Higgs, "y_Higgs", 80, -4, 4);
       book(hist_pT_V, "pT_V", 80, 0, 400);
@@ -848,6 +1091,7 @@ namespace Rivet {
       book(hist_pT_Hjj, "pT_Hjj", 50, 0, 250);
       book(hist_Njets25, "Njets25", 10, 0, 10);
       book(hist_Njets30, "Njets30", 10, 0, 10);
+      book(hist_isZ2vv, "isZ2vv",2,0,2);
     }
     /// @}
 
@@ -862,10 +1106,13 @@ namespace Rivet {
     std::map<HTXS::ErrorCode, size_t> m_errorCount;
     Histo1DPtr hist_stage0;
     Histo1DPtr hist_stage1_pTjet25, hist_stage1_pTjet30;
+    Histo1DPtr hist_stage1_2_pTjet25, hist_stage1_2_pTjet30;
+    Histo1DPtr hist_stage1_2_fine_pTjet25, hist_stage1_2_fine_pTjet30;
     Histo1DPtr hist_pT_Higgs, hist_y_Higgs;
     Histo1DPtr hist_pT_V, hist_pT_jet1;
     Histo1DPtr hist_deltay_jj, hist_dijet_mass, hist_pT_Hjj;
     Histo1DPtr hist_Njets25, hist_Njets30;
+    Histo1DPtr hist_isZ2vv;
   };
 
   // the PLUGIN only needs to be decleared when running standalone Rivet

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -92,7 +92,6 @@ namespace Rivet {
       return false;
     }
 
-
     /// @brief Returns the classification object with the error code set.
     ///        Prints an warning message, and keeps track of number of errors
     HiggsClassification error(HiggsClassification &cat,
@@ -132,7 +131,6 @@ namespace Rivet {
       cat.stage1_2_cat_pTjet30GeV = HTXS::Stage1_2::UNKNOWN;
       cat.stage1_2_fine_cat_pTjet25GeV = HTXS::Stage1_2_Fine::UNKNOWN;
       cat.stage1_2_fine_cat_pTjet30GeV = HTXS::Stage1_2_Fine::UNKNOWN;
-
 
       if (prodMode == HTXS::UNKNOWN)
         return error(cat,
@@ -362,11 +360,11 @@ namespace Rivet {
       return VBFtopo ? (j1 + j2 + higgs.momentum()).pt() < 25 ? 2 : 1 : 0;
     }
 
-    /// @brief VBF topology selection Stage1.1
+    /// @brief VBF topology selection Stage1.1 and Stage1.2
     /// 0 = fail loose selection: m_jj > 350 GeV
     /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
     /// 3 pass tight (m_jj>700 GeV), but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
-    int vbfTopology_Stage1_1(const Jets &jets, const Particle &higgs) {
+    int vbfTopology_Stage1_X(const Jets &jets, const Particle &higgs) {
       if (jets.size() < 2)
         return 0;
       const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
@@ -379,31 +377,13 @@ namespace Rivet {
         return 0;
     }
 
-    /// @brief VBF topology selection Stage1.2
-    /// 0 = fail loose selection: m_jj > 350 GeV
-    /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
-    /// 3 pass tight (m_jj>700 GeV), but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
-    int vbfTopology_Stage1_2(const Jets &jets, const Particle &higgs) {
-      if (jets.size() < 2)
-        return 0;
-      const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
-      double mjj = (j1 + j2).mass();
-      if (mjj > 350 && mjj <= 700)
-        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 1 : 2;
-      else if (mjj > 700)
-        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 3 : 4;
-      else
-        return 0;
-    }
-
-
-    /// @brief VBF topology selection for Stage1.1 Fine
+    /// @brief VBF topology selection for Stage1.1 and Stage 1.2 Fine
     /// 0 = fail loose selection: m_jj > 350 GeV
     /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
     /// 3 pass 700<m_jj<1000 GeV, but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
     /// 5 pass 1000<m_jj<1500 GeV, but fail additional cut pT(Hjj)<25. 6 pass pT(Hjj)>25 selection
     /// 7 pass m_jj>1500 GeV, but fail additional cut pT(Hjj)<25. 8 pass pT(Hjj)>25 selection
-    int vbfTopology_Stage1_1_Fine(const Jets &jets, const Particle &higgs) {
+    int vbfTopology_Stage1_X_Fine(const Jets &jets, const Particle &higgs) {
       if (jets.size() < 2)
         return 0;
       const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
@@ -419,23 +399,6 @@ namespace Rivet {
       else
         return 0;
     }
-    /// @brief VBF topology selection for Stage1_2
-    /// 0 = fail loose selection: m_jj > 350 GeV
-    /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
-    /// 3 pass 700<m_jj<1000 GeV, but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
-    /// 5 pass 1000<m_jj<1500 GeV, but fail additional cut pT(Hjj)<25. 6 pass pT(Hjj)>25 selection
-    /// 7 pass m_jj>1500 GeV, but fail additional cut pT(Hjj)<25. 8 pass pT(Hjj)>25 selection
-    int vbfTopology_Stage1_2_Fine(const Jets &jets, const Particle &higgs) {
-      if (jets.size()<2) return 0;
-      const FourMomentum &j1=jets[0].momentum(), &j2=jets[1].momentum();
-      double mjj = (j1+j2).mass();
-      if(mjj>350 && mjj<=700) return (j1+j2+higgs.momentum()).pt()<25 ? 1 : 2;
-      else if(mjj>700 && mjj<=1000) return (j1+j2+higgs.momentum()).pt()<25 ? 3 : 4;
-      else if(mjj>1000 && mjj<=1500) return (j1+j2+higgs.momentum()).pt()<25 ? 5 : 6;
-      else if(mjj>1500) return (j1+j2+higgs.momentum()).pt()<25 ? 7 : 8;
-      else return 0;
-    }
-
 
     /// @brief Whether the Higgs is produced in association with a vector boson (VH)
     bool isVH(HTXS::HiggsProdMode p) { return p == HTXS::WH || p == HTXS::QQ2ZH || p == HTXS::GG2ZH; }
@@ -551,7 +514,7 @@ namespace Rivet {
                                                   const Particle &V) {
       using namespace HTXS::Stage1_1;
       int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology_Stage1_1(jets, higgs);
+      int vbfTopo = vbfTopology_Stage1_X(jets, higgs);
 
       // 1. GGF Stage 1 categories
       //    Following YR4 write-up: XXXXX
@@ -653,7 +616,7 @@ namespace Rivet {
                                                             const Particle &V) {
       using namespace HTXS::Stage1_1_Fine;
       int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology_Stage1_1_Fine(jets, higgs);
+      int vbfTopo = vbfTopology_Stage1_X_Fine(jets, higgs);
 
       // 1. GGF Stage 1.1 categories
       //    Following YR4 write-up: XXXXX
@@ -756,7 +719,7 @@ namespace Rivet {
 					     const Particle &V) {
       using namespace HTXS::Stage1_2;
       int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology(jets,higgs);
+      int vbfTopo = vbfTopology_Stage1_X(jets,higgs);
 
       // 1. GGF Stage 1 categories
       //    Following YR4 write-up: XXXXX
@@ -833,7 +796,7 @@ namespace Rivet {
                          const Particle &V) {
       using namespace HTXS::Stage1_2_Fine;
       int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology_Stage1_2_Fine(jets,higgs);
+      int vbfTopo = vbfTopology_Stage1_X_Fine(jets,higgs);
 
       // 1. GGF Stage 1.2 categories
       //    Following YR4 write-up: XXXXX
@@ -1000,7 +963,6 @@ namespace Rivet {
       hist_stage1_2_pTjet30->fill(cat.stage1_2_cat_pTjet30GeV%100 + off1_2, weight);
       hist_stage1_2_fine_pTjet25->fill(cat.stage1_2_fine_cat_pTjet25GeV%100 + off1_2f, weight);
       hist_stage1_2_fine_pTjet30->fill(cat.stage1_2_fine_cat_pTjet30GeV%100 + off1_2f, weight);
-
 
       // Fill histograms: variables used in the categorization
       hist_pT_Higgs->fill(cat.higgs.pT(), weight);

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -87,8 +87,9 @@ namespace Rivet {
 
     /// @brief Return true if particle decays to charged leptons.
     bool ChLeptonDecay(const Particle &p) {
-      for (auto child:p.children())
-        if (PID::isChLepton(child.pid())) return true;
+      for (auto child : p.children())
+        if (PID::isChLepton(child.pid()))
+          return true;
       return false;
     }
 
@@ -314,7 +315,8 @@ namespace Rivet {
 
       // Apply the categorization categorization
       cat.isZ2vvDecay = false;
-      if( (prodMode==HTXS::GG2ZH || prodMode==HTXS::QQ2ZH) && !quarkDecay(cat.V) && !ChLeptonDecay(cat.V) ) cat.isZ2vvDecay = true;
+      if ((prodMode == HTXS::GG2ZH || prodMode == HTXS::QQ2ZH) && !quarkDecay(cat.V) && !ChLeptonDecay(cat.V))
+        cat.isZ2vvDecay = true;
       cat.stage0_cat = getStage0Category(prodMode, cat.higgs, cat.V);
       cat.stage1_cat_pTjet25GeV = getStage1Category(prodMode, cat.higgs, cat.jets25, cat.V);
       cat.stage1_cat_pTjet30GeV = getStage1Category(prodMode, cat.higgs, cat.jets30, cat.V);
@@ -322,11 +324,10 @@ namespace Rivet {
       cat.stage1_1_cat_pTjet30GeV = getStage1_1_Category(prodMode, cat.higgs, cat.jets30, cat.V);
       cat.stage1_1_fine_cat_pTjet25GeV = getStage1_1_Fine_Category(prodMode, cat.higgs, cat.jets25, cat.V);
       cat.stage1_1_fine_cat_pTjet30GeV = getStage1_1_Fine_Category(prodMode, cat.higgs, cat.jets30, cat.V);
-      cat.stage1_2_cat_pTjet25GeV = getStage1_2_Category(prodMode,cat.higgs,cat.jets25,cat.V);
-      cat.stage1_2_cat_pTjet30GeV = getStage1_2_Category(prodMode,cat.higgs,cat.jets30,cat.V);
-      cat.stage1_2_fine_cat_pTjet25GeV = getStage1_2_Fine_Category(prodMode,cat.higgs,cat.jets25,cat.V);
-      cat.stage1_2_fine_cat_pTjet30GeV = getStage1_2_Fine_Category(prodMode,cat.higgs,cat.jets30,cat.V);
-
+      cat.stage1_2_cat_pTjet25GeV = getStage1_2_Category(prodMode, cat.higgs, cat.jets25, cat.V);
+      cat.stage1_2_cat_pTjet30GeV = getStage1_2_Category(prodMode, cat.higgs, cat.jets30, cat.V);
+      cat.stage1_2_fine_cat_pTjet25GeV = getStage1_2_Fine_Category(prodMode, cat.higgs, cat.jets25, cat.V);
+      cat.stage1_2_fine_cat_pTjet30GeV = getStage1_2_Fine_Category(prodMode, cat.higgs, cat.jets30, cat.V);
 
       cat.errorCode = HTXS::SUCCESS;
       ++m_errorCount[HTXS::SUCCESS];
@@ -714,167 +715,220 @@ namespace Rivet {
 
     /// @brief Stage-1.2 categorization
     HTXS::Stage1_2::Category getStage1_2_Category(const HTXS::HiggsProdMode prodMode,
-					     const Particle &higgs,
-					     const Jets &jets,
-					     const Particle &V) {
+                                                  const Particle &higgs,
+                                                  const Jets &jets,
+                                                  const Particle &V) {
       using namespace HTXS::Stage1_2;
-      int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology_Stage1_X(jets,higgs);
+      int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology_Stage1_X(jets, higgs);
 
       // 1. GGF Stage 1 categories
       //    Following YR4 write-up: XXXXX
-      if (prodMode==HTXS::GGF || (prodMode==HTXS::GG2ZH && quarkDecay(V)) ) {
-    if (fwdHiggs)        return GG2H_FWDH;
-    if ( higgs.pt()>200 ) return Category(GG2H_PTH_200_300+getBin(higgs.pt(),{200,300,450,650}));
-    if (Njets==0)  return higgs.pt()<10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
-    if (Njets==1)  return Category(GG2H_1J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
-    if (Njets>1){
-        //VBF topology
-        if(vbfTopo) return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25+vbfTopo-1);
-        //Njets >= 2jets without VBF topology (mjj<350)
-        return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
+      if (prodMode == HTXS::GGF || (prodMode == HTXS::GG2ZH && quarkDecay(V))) {
+        if (fwdHiggs)
+          return GG2H_FWDH;
+        if (higgs.pt() > 200)
+          return Category(GG2H_PTH_200_300 + getBin(higgs.pt(), {200, 300, 450, 650}));
+        if (Njets == 0)
+          return higgs.pt() < 10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
+        if (Njets == 1)
+          return Category(GG2H_1J_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        if (Njets > 1) {
+          //VBF topology
+          if (vbfTopo)
+            return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 + vbfTopo - 1);
+          //Njets >= 2jets without VBF topology (mjj<350)
+          return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        }
       }
-    }
 
       // 2. Electroweak qq->Hqq Stage 1.2 categories
-      else if (prodMode==HTXS::VBF || ( isVH(prodMode) && quarkDecay(V)) ) {
-    if (std::abs(higgs.rapidity())>2.5) return QQ2HQQ_FWDH;
-    int Njets=jets.size();
-    if (Njets==0)        return QQ2HQQ_0J;
-    else if (Njets==1)   return QQ2HQQ_1J;
-    else if (Njets>=2) {
-        double mjj = (jets[0].mom()+jets[1].mom()).mass();
-        if ( mjj < 60 )      return QQ2HQQ_GE2J_MJJ_0_60;
-        else if ( 60 < mjj && mjj < 120 ) return QQ2HQQ_GE2J_MJJ_60_120;
-        else if ( 120 < mjj && mjj < 350 ) return QQ2HQQ_GE2J_MJJ_120_350;
-        else if (  mjj > 350 ) {
-            if (higgs.pt()>200) return QQ2HQQ_GE2J_MJJ_GT350_PTH_GT200;
-            if(vbfTopo) return Category(QQ2HQQ_GE2J_MJJ_GT350_PTH_GT200+vbfTopo);
+      else if (prodMode == HTXS::VBF || (isVH(prodMode) && quarkDecay(V))) {
+        if (std::abs(higgs.rapidity()) > 2.5)
+          return QQ2HQQ_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return QQ2HQQ_0J;
+        else if (Njets == 1)
+          return QQ2HQQ_1J;
+        else if (Njets >= 2) {
+          double mjj = (jets[0].mom() + jets[1].mom()).mass();
+          if (mjj < 60)
+            return QQ2HQQ_GE2J_MJJ_0_60;
+          else if (60 < mjj && mjj < 120)
+            return QQ2HQQ_GE2J_MJJ_60_120;
+          else if (120 < mjj && mjj < 350)
+            return QQ2HQQ_GE2J_MJJ_120_350;
+          else if (mjj > 350) {
+            if (higgs.pt() > 200)
+              return QQ2HQQ_GE2J_MJJ_GT350_PTH_GT200;
+            if (vbfTopo)
+              return Category(QQ2HQQ_GE2J_MJJ_GT350_PTH_GT200 + vbfTopo);
+          }
         }
-    }
       }
       // 3. WH->Hlv categories
-      else if (prodMode==HTXS::WH) {
-        if (fwdHiggs) return QQ2HLNU_FWDH;
-        else if (V.pt()<75) return QQ2HLNU_PTV_0_75;
-        else if (V.pt()<150) return QQ2HLNU_PTV_75_150;
-      	else if (V.pt()>250) return QQ2HLNU_PTV_GT250;
-      	// 150 < pTV/GeV < 250
-      	return jets.empty() ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
+      else if (prodMode == HTXS::WH) {
+        if (fwdHiggs)
+          return QQ2HLNU_FWDH;
+        else if (V.pt() < 75)
+          return QQ2HLNU_PTV_0_75;
+        else if (V.pt() < 150)
+          return QQ2HLNU_PTV_75_150;
+        else if (V.pt() > 250)
+          return QQ2HLNU_PTV_GT250;
+        // 150 < pTV/GeV < 250
+        return jets.empty() ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
       }
       // 4. qq->ZH->llH categories
-      else if (prodMode==HTXS::QQ2ZH) {
-        if (fwdHiggs) return QQ2HLL_FWDH;
-        else if (V.pt()<75) return QQ2HLL_PTV_0_75;
-        else if (V.pt()<150) return QQ2HLL_PTV_75_150;
-      	else if (V.pt()>250) return QQ2HLL_PTV_GT250;
-      	// 150 < pTV/GeV < 250
-      	return jets.empty() ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
+      else if (prodMode == HTXS::QQ2ZH) {
+        if (fwdHiggs)
+          return QQ2HLL_FWDH;
+        else if (V.pt() < 75)
+          return QQ2HLL_PTV_0_75;
+        else if (V.pt() < 150)
+          return QQ2HLL_PTV_75_150;
+        else if (V.pt() > 250)
+          return QQ2HLL_PTV_GT250;
+        // 150 < pTV/GeV < 250
+        return jets.empty() ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
       }
       // 5. gg->ZH->llH categories
-      else if (prodMode==HTXS::GG2ZH ) {
-        if (fwdHiggs) return GG2HLL_FWDH;
-        else if (V.pt()<75) return GG2HLL_PTV_0_75;
-        else if (V.pt()<150) return GG2HLL_PTV_75_150;
-        else if (V.pt()>250) return GG2HLL_PTV_GT250;
+      else if (prodMode == HTXS::GG2ZH) {
+        if (fwdHiggs)
+          return GG2HLL_FWDH;
+        else if (V.pt() < 75)
+          return GG2HLL_PTV_0_75;
+        else if (V.pt() < 150)
+          return GG2HLL_PTV_75_150;
+        else if (V.pt() > 250)
+          return GG2HLL_PTV_GT250;
         return jets.empty() ? GG2HLL_PTV_150_250_0J : GG2HLL_PTV_150_250_GE1J;
       }
       // 6.ttH,bbH,tH categories
-      else if (prodMode==HTXS::TTH) {
-        if (fwdHiggs) return TTH_FWDH;
-        else return Category(TTH_PTH_0_60+getBin(higgs.pt(),{0,60,120,200,300}));
-      }
-      else if (prodMode==HTXS::BBH) return Category(BBH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::TH ) return Category(TH_FWDH+ctrlHiggs);
+      else if (prodMode == HTXS::TTH) {
+        if (fwdHiggs)
+          return TTH_FWDH;
+        else
+          return Category(TTH_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200, 300}));
+      } else if (prodMode == HTXS::BBH)
+        return Category(BBH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::TH)
+        return Category(TH_FWDH + ctrlHiggs);
       return UNKNOWN;
     }
 
     /// @brief Stage-1.2 Fine categorization
     HTXS::Stage1_2_Fine::Category getStage1_2_Fine_Category(const HTXS::HiggsProdMode prodMode,
-                         const Particle &higgs,
-                         const Jets &jets,
-                         const Particle &V) {
+                                                            const Particle &higgs,
+                                                            const Jets &jets,
+                                                            const Particle &V) {
       using namespace HTXS::Stage1_2_Fine;
-      int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology_Stage1_X_Fine(jets,higgs);
+      int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology_Stage1_X_Fine(jets, higgs);
 
       // 1. GGF Stage 1.2 categories
       //    Following YR4 write-up: XXXXX
-      if (prodMode==HTXS::GGF || (prodMode==HTXS::GG2ZH && quarkDecay(V)) ) {
-    if (fwdHiggs)        return GG2H_FWDH;
-    if ( higgs.pt()>200 ){
-      if (Njets>0){
-        double pTHj = (jets[0].momentum()+higgs.momentum()).pt();
-        if( pTHj/higgs.pt()>0.15 ) return Category(GG2H_PTH_200_300_PTHJoverPTH_GT15+getBin(higgs.pt(),{200,300,450,650}));
-        else return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15+getBin(higgs.pt(),{200,300,450,650}));
-      }
-      else return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15+getBin(higgs.pt(),{200,300,450,650}));
-    }
-    if (Njets==0)  return higgs.pt()<10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
-    if (Njets==1)  return Category(GG2H_1J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
-    if (Njets>1){
-        //double mjj = (jets[0].mom()+jets[1].mom()).mass();
-        double pTHjj = (jets[0].momentum()+jets[1].momentum()+higgs.momentum()).pt();
-        //VBF topology
-        if(vbfTopo) return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25+vbfTopo-1);
-        //Njets >= 2jets without VBF topology (mjj<350)
-        if (pTHjj<25) return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_0_25+getBin(higgs.pt(),{0,60,120,200}));
-        else return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_GT25+getBin(higgs.pt(),{0,60,120,200}));
-    }
+      if (prodMode == HTXS::GGF || (prodMode == HTXS::GG2ZH && quarkDecay(V))) {
+        if (fwdHiggs)
+          return GG2H_FWDH;
+        if (higgs.pt() > 200) {
+          if (Njets > 0) {
+            double pTHj = (jets[0].momentum() + higgs.momentum()).pt();
+            if (pTHj / higgs.pt() > 0.15)
+              return Category(GG2H_PTH_200_300_PTHJoverPTH_GT15 + getBin(higgs.pt(), {200, 300, 450, 650}));
+            else
+              return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15 + getBin(higgs.pt(), {200, 300, 450, 650}));
+          } else
+            return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15 + getBin(higgs.pt(), {200, 300, 450, 650}));
+        }
+        if (Njets == 0)
+          return higgs.pt() < 10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
+        if (Njets == 1)
+          return Category(GG2H_1J_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        if (Njets > 1) {
+          //double mjj = (jets[0].mom()+jets[1].mom()).mass();
+          double pTHjj = (jets[0].momentum() + jets[1].momentum() + higgs.momentum()).pt();
+          //VBF topology
+          if (vbfTopo)
+            return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 + vbfTopo - 1);
+          //Njets >= 2jets without VBF topology (mjj<350)
+          if (pTHjj < 25)
+            return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_0_25 + getBin(higgs.pt(), {0, 60, 120, 200}));
+          else
+            return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_GT25 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        }
       }
 
       // 2. Electroweak qq->Hqq Stage 1.2 categories
-      else if (prodMode==HTXS::VBF || ( isVH(prodMode) && quarkDecay(V)) ) {
-    if (std::abs(higgs.rapidity())>2.5) return QQ2HQQ_FWDH;
-    int Njets=jets.size();
-    if (Njets==0)        return QQ2HQQ_0J;
-    else if (Njets==1)   return QQ2HQQ_1J;
-    else if (Njets>=2) {
-        double mjj = (jets[0].mom()+jets[1].mom()).mass();
-        double pTHjj = (jets[0].momentum()+jets[1].momentum()+higgs.momentum()).pt();
-        if (mjj<350){
-            if (pTHjj<25) return Category(QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_0_25+getBin(mjj,{0,60,120,350}));
-            else return Category(QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_GT25+getBin(mjj,{0,60,120,350}));
-        } else { //mjj>350 GeV
-            if (higgs.pt()<200){
-                return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25+vbfTopo-1);
+      else if (prodMode == HTXS::VBF || (isVH(prodMode) && quarkDecay(V))) {
+        if (std::abs(higgs.rapidity()) > 2.5)
+          return QQ2HQQ_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return QQ2HQQ_0J;
+        else if (Njets == 1)
+          return QQ2HQQ_1J;
+        else if (Njets >= 2) {
+          double mjj = (jets[0].mom() + jets[1].mom()).mass();
+          double pTHjj = (jets[0].momentum() + jets[1].momentum() + higgs.momentum()).pt();
+          if (mjj < 350) {
+            if (pTHjj < 25)
+              return Category(QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_0_25 + getBin(mjj, {0, 60, 120, 350}));
+            else
+              return Category(QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_GT25 + getBin(mjj, {0, 60, 120, 350}));
+          } else {  //mjj>350 GeV
+            if (higgs.pt() < 200) {
+              return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 + vbfTopo - 1);
             } else {
-                return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_GT200_PTHJJ_0_25+vbfTopo-1);
+              return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_GT200_PTHJJ_0_25 + vbfTopo - 1);
             }
+          }
         }
-    }
       }
       // 3. WH->Hlv categories
-      else if (prodMode==HTXS::WH) {
-        if (fwdHiggs) return QQ2HLNU_FWDH;
-        int Njets=jets.size();
-        if (Njets==0) return Category(QQ2HLNU_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
-        if (Njets==1) return Category(QQ2HLNU_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
-        return Category(QQ2HLNU_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      else if (prodMode == HTXS::WH) {
+        if (fwdHiggs)
+          return QQ2HLNU_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return Category(QQ2HLNU_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        if (Njets == 1)
+          return Category(QQ2HLNU_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        return Category(QQ2HLNU_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400}));
       }
       // 4. qq->ZH->llH categories
-      else if (prodMode==HTXS::QQ2ZH) {
-        if (fwdHiggs) return QQ2HLL_FWDH;
-        int Njets=jets.size();
-        if (Njets==0) return Category(QQ2HLL_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
-        if (Njets==1) return Category(QQ2HLL_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
-        return Category(QQ2HLL_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      else if (prodMode == HTXS::QQ2ZH) {
+        if (fwdHiggs)
+          return QQ2HLL_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return Category(QQ2HLL_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        if (Njets == 1)
+          return Category(QQ2HLL_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        return Category(QQ2HLL_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400}));
       }
       // 5. gg->ZH->llH categories
-      else if (prodMode==HTXS::GG2ZH ) {
-        if (fwdHiggs) return GG2HLL_FWDH;
-        int Njets=jets.size();
-        if (Njets==0) return Category(GG2HLL_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
-        if (Njets==1) return Category(GG2HLL_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
-        return Category(GG2HLL_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      else if (prodMode == HTXS::GG2ZH) {
+        if (fwdHiggs)
+          return GG2HLL_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return Category(GG2HLL_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        if (Njets == 1)
+          return Category(GG2HLL_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        return Category(GG2HLL_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400}));
       }
       // 6.ttH,bbH,tH categories
-      else if (prodMode==HTXS::TTH) {
-        if (fwdHiggs) return TTH_FWDH;
-        else return Category(TTH_PTH_0_60+getBin(higgs.pt(),{0,60,120,200,300,450}));
-      }
-      else if (prodMode==HTXS::BBH) return Category(BBH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::TH ) return Category(TH_FWDH+ctrlHiggs);
+      else if (prodMode == HTXS::TTH) {
+        if (fwdHiggs)
+          return TTH_FWDH;
+        else
+          return Category(TTH_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200, 300, 450}));
+      } else if (prodMode == HTXS::BBH)
+        return Category(BBH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::TH)
+        return Category(TH_FWDH + ctrlHiggs);
       return UNKNOWN;
     }
 
@@ -954,15 +1008,15 @@ namespace Rivet {
       hist_stage1_pTjet30->fill(cat.stage1_cat_pTjet30GeV % 100 + off, weight);
 
       // Stage 1_2 enum offsets for each production mode: GGF=17, VBF=11, WH= 6, QQ2ZH=6, GG2ZH=6, TTH=6, BBH=2, TH=2
-      static vector<int> offset1_2({0,1,18,29,35,41,47,53,55,57}); 
+      static vector<int> offset1_2({0, 1, 18, 29, 35, 41, 47, 53, 55, 57});
       int off1_2 = offset1_2[P];
       // Stage 1_2 Fine enum offsets for each production mode: GGF=28, VBF=25, WH= 16, QQ2ZH=16, GG2ZH=16, TTH=7, BBH=2, TH=2
-      static vector<int> offset1_2f({0,1,29,54,70,86,102,109,111,113});
+      static vector<int> offset1_2f({0, 1, 29, 54, 70, 86, 102, 109, 111, 113});
       int off1_2f = offset1_2f[P];
-      hist_stage1_2_pTjet25->fill(cat.stage1_2_cat_pTjet25GeV%100 + off1_2, weight);
-      hist_stage1_2_pTjet30->fill(cat.stage1_2_cat_pTjet30GeV%100 + off1_2, weight);
-      hist_stage1_2_fine_pTjet25->fill(cat.stage1_2_fine_cat_pTjet25GeV%100 + off1_2f, weight);
-      hist_stage1_2_fine_pTjet30->fill(cat.stage1_2_fine_cat_pTjet30GeV%100 + off1_2f, weight);
+      hist_stage1_2_pTjet25->fill(cat.stage1_2_cat_pTjet25GeV % 100 + off1_2, weight);
+      hist_stage1_2_pTjet30->fill(cat.stage1_2_cat_pTjet30GeV % 100 + off1_2, weight);
+      hist_stage1_2_fine_pTjet25->fill(cat.stage1_2_fine_cat_pTjet25GeV % 100 + off1_2f, weight);
+      hist_stage1_2_fine_pTjet30->fill(cat.stage1_2_fine_cat_pTjet30GeV % 100 + off1_2f, weight);
 
       // Fill histograms: variables used in the categorization
       hist_pT_Higgs->fill(cat.higgs.pT(), weight);
@@ -1040,10 +1094,10 @@ namespace Rivet {
       book(hist_stage0, "HTXS_stage0", 20, 0, 20);
       book(hist_stage1_pTjet25, "HTXS_stage1_pTjet25", 40, 0, 40);
       book(hist_stage1_pTjet30, "HTXS_stage1_pTjet30", 40, 0, 40);
-      book(hist_stage1_2_pTjet25, "HTXS_stage1_2_pTjet25",57,0,57);
-      book(hist_stage1_2_pTjet30, "HTXS_stage1_2_pTjet30",57,0,57);
-      book(hist_stage1_2_pTjet25, "HTXS_stage1_2_fine_pTjet25",113,0,113);
-      book(hist_stage1_2_fine_pTjet30, "HTXS_stage1_2_fine_pTjet30",113,0,113);
+      book(hist_stage1_2_pTjet25, "HTXS_stage1_2_pTjet25", 57, 0, 57);
+      book(hist_stage1_2_pTjet30, "HTXS_stage1_2_pTjet30", 57, 0, 57);
+      book(hist_stage1_2_pTjet25, "HTXS_stage1_2_fine_pTjet25", 113, 0, 113);
+      book(hist_stage1_2_fine_pTjet30, "HTXS_stage1_2_fine_pTjet30", 113, 0, 113);
       book(hist_pT_Higgs, "pT_Higgs", 80, 0, 400);
       book(hist_y_Higgs, "y_Higgs", 80, -4, 4);
       book(hist_pT_V, "pT_V", 80, 0, 400);
@@ -1053,7 +1107,7 @@ namespace Rivet {
       book(hist_pT_Hjj, "pT_Hjj", 50, 0, 250);
       book(hist_Njets25, "Njets25", 10, 0, 10);
       book(hist_Njets30, "Njets30", 10, 0, 10);
-      book(hist_isZ2vv, "isZ2vv",2,0,2);
+      book(hist_isZ2vv, "isZ2vv", 2, 0, 2);
     }
     /// @}
 

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -1096,7 +1096,7 @@ namespace Rivet {
       book(hist_stage1_pTjet30, "HTXS_stage1_pTjet30", 40, 0, 40);
       book(hist_stage1_2_pTjet25, "HTXS_stage1_2_pTjet25", 57, 0, 57);
       book(hist_stage1_2_pTjet30, "HTXS_stage1_2_pTjet30", 57, 0, 57);
-      book(hist_stage1_2_pTjet25, "HTXS_stage1_2_fine_pTjet25", 113, 0, 113);
+      book(hist_stage1_2_fine_pTjet25, "HTXS_stage1_2_fine_pTjet25", 113, 0, 113);
       book(hist_stage1_2_fine_pTjet30, "HTXS_stage1_2_fine_pTjet30", 113, 0, 113);
       book(hist_pT_Higgs, "pT_Higgs", 80, 0, 400);
       book(hist_y_Higgs, "y_Higgs", 80, -4, 4);

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -17,6 +17,8 @@
 <use   name="DQMServices/Core"/>
 <use   name="CondFormats/BTauObjects"/>
 <use   name="CondTools/BTau"/>
+<use   name="RecoVertex/KalmanVertexFit"/>
+<use   name="MagneticField/Records"/>
 <library   file="*.cc" name="PhysicsToolsNanoAODPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/PhysicsTools/NanoAOD/plugins/DiMuonVertexProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/DiMuonVertexProducer.cc
@@ -1,0 +1,217 @@
+// -*- C++ -*-
+//
+// Package:    PhysicsTools/NanoAOD
+// Class:      DiMuonVertexProducer
+// 
+/*
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  George Karathanasis georgios.karathanasis@cern.ch
+//         Created:  Mon, 7 Dec 2019 09:26:39 GMT
+//
+//
+
+
+
+// system include files
+#include <memory>
+#include <sstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "SecondaryVertexFitter.h"
+
+constexpr float MUON_MASS= 0.105;
+
+typedef std::vector<reco::TransientTrack> TransientTrackCollection;
+typedef std::vector<pat::CompositeCandidate> CompositeCandidateCollection;
+
+
+class DiMuonVertexProducer : public edm::stream::EDProducer<> {
+
+  public:
+     explicit DiMuonVertexProducer(const edm::ParameterSet &iConfig) :
+       muons_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+       bspot_{consumes<reco::BeamSpot>( iConfig.getParameter<edm::InputTag>("beamSpot") )},
+       pvs_{consumes< std::vector<reco::Vertex> >( iConfig.getParameter<edm::InputTag>("vertices") )},
+       mu1_cuts_{iConfig.getParameter<std::string>("mu1Selection")},
+       mu2_cuts_{iConfig.getParameter<std::string>("mu2Selection")},
+       pre_vtxfit_cuts_{iConfig.getParameter<std::string>("preVtxSelection")},
+       post_vtxfit_cuts_{iConfig.getParameter<std::string>("postVtxSelection")},
+       refit_{iConfig.getParameter<bool>("RefitTracks")},
+       fitTunePTransientTracks_{iConfig.getParameter<bool>("FitTunePTransientTracks")}
+       {       
+          produces<pat::CompositeCandidateCollection>("diMuons");
+       }
+
+        ~DiMuonVertexProducer() override {}
+
+    private:
+        void produce(edm::Event&, edm::EventSetup const&) override ;
+
+        const edm::EDGetTokenT<pat::MuonCollection> muons_;
+        const edm::EDGetTokenT<reco::BeamSpot> bspot_; 
+        const edm::EDGetTokenT<std::vector<reco::Vertex>> pvs_;
+        const StringCutObjectSelector<pat::Muon> mu1_cuts_;
+        const StringCutObjectSelector<pat::Muon> mu2_cuts_;
+        const StringCutObjectSelector<pat::CompositeCandidate> pre_vtxfit_cuts_;
+        const StringCutObjectSelector<pat::CompositeCandidate> post_vtxfit_cuts_;        
+        bool refit_;
+        bool fitTunePTransientTracks_=false;
+              
+};
+
+// ------------ method called to produce the data  ------------
+void
+DiMuonVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
+{
+   
+    edm::Handle<pat::MuonCollection> muons;
+    iEvent.getByToken(muons_, muons);
+    edm::Handle<reco::BeamSpot> bspot;
+    iEvent.getByToken(bspot_, bspot);  
+    edm::Handle<std::vector<reco::Vertex>> pvs;
+    iEvent.getByToken(pvs_, pvs);  
+
+    edm::ESHandle<MagneticField> bFieldHandle;
+    iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
+     
+    std::unique_ptr<pat::CompositeCandidateCollection> pairs(new pat::CompositeCandidateCollection());
+    math::XYZPoint pv = (pvs->front()).position();
+
+    // muon pair creation 
+    for( pat::MuonCollection::const_iterator mu= muons->begin(); mu!=muons->end(); ++mu){
+      // remove mu not qualified for trailing mu
+      if ( !mu2_cuts_(*mu) ) continue;
+
+      for( pat::MuonCollection::const_iterator mu2= mu+1; mu2!=muons->end(); ++mu2){
+        // remove mu not qualified for trailing mu
+        if ( !mu2_cuts_(*mu2) ) continue;
+         // remove mu not qualified for leading mu        
+        if ( !mu1_cuts_(*mu) && !mu1_cuts_(*mu2) ) continue;
+
+        //create pair
+        pat::CompositeCandidate muon_pair;
+        muon_pair.setP4(mu->p4() + mu2->p4());
+        muon_pair.setCharge(mu->charge() + mu2->charge());
+        muon_pair.addUserFloat("deltaR", reco::deltaR(*mu, *mu2));
+
+        // cut before vertex
+        if ( !pre_vtxfit_cuts_(muon_pair) ) continue;
+        reco::TransientTrack tranmu1((*(mu->bestTrack())), &(*bFieldHandle));
+        reco::TransientTrack tranmu2((*(mu2->bestTrack())), &(*bFieldHandle));
+
+        if(fitTunePTransientTracks_){
+          tranmu1=reco::TransientTrack((*(mu->tunePMuonBestTrack() )), &(*bFieldHandle));
+          tranmu2=reco::TransientTrack((*(mu2->tunePMuonBestTrack() )), &(*bFieldHandle));
+        }
+
+        //fit
+        TransientTrackCollection mutrk{ tranmu1, tranmu2};
+        SecondaryVertexFitter vtx(mutrk,{MUON_MASS,MUON_MASS},refit_);
+
+        // remove failures
+        if ( !vtx.success() ) continue;
+
+        //pair after fit
+        muon_pair.addUserFloat("fit_pt",vtx.motherP4().pt());
+        muon_pair.addUserFloat("fit_eta",vtx.motherP4().eta());
+        muon_pair.addUserFloat("fit_phi",vtx.motherP4().phi());
+        muon_pair.addUserFloat("fit_mass",vtx.motherP4().mass());
+        muon_pair.addUserFloat("fit_charge",vtx.motherCh());
+
+        //vertex quality
+        muon_pair.addUserFloat("chi2",vtx.chi2());
+        muon_pair.addUserFloat("dof",vtx.dof());
+        muon_pair.addUserFloat("prob",vtx.prob());
+
+        //vertex position
+        muon_pair.addUserFloat("vtx_x",vtx.motherXYZ().x());
+        muon_pair.addUserFloat("vtx_y",vtx.motherXYZ().y());
+        muon_pair.addUserFloat("vtx_z",vtx.motherXYZ().z());
+
+        //distance variables
+	GlobalPoint Dispbeamspot(
+				 -1*((bspot->x0()-vtx.motherXYZ().x())+(vtx.motherXYZ().z()-bspot->z0())* bspot->dxdz()),
+				 -1*((bspot->y0()-vtx.motherXYZ().y())+ (vtx.motherXYZ().z()-bspot->z0()) * bspot->dydz()), 0);
+
+        float Lxy = Dispbeamspot.perp();  
+        float eLxy= vtx.motherXYZError().rerr(Dispbeamspot); 
+        eLxy = TMath::Sqrt( eLxy );
+
+        muon_pair.addUserFloat("IP_fromBS",Lxy);
+        muon_pair.addUserFloat("EIP_fromBS",eLxy);
+        muon_pair.addUserFloat("SIP_fromBS",eLxy !=0 ? Lxy/eLxy : 0);
+	
+        GlobalPoint DispFromPV(
+			        pv.x()-vtx.motherXYZ().x(),
+			        pv.y()-vtx.motherXYZ().y(), 
+                                0 
+                               );
+
+        float LxyPV = DispFromPV.perp();  
+        float eLxyPV= vtx.motherXYZError().rerr(DispFromPV); 
+        eLxyPV = TMath::Sqrt( eLxyPV );
+
+        muon_pair.addUserFloat("IP_fromPV",LxyPV);
+        muon_pair.addUserFloat("EIP_fromPV",eLxyPV);
+        muon_pair.addUserFloat("SIP_fromPV",eLxyPV != 0 ? LxyPV/eLxyPV : 0);
+
+        //daughter refited
+	std::vector<unsigned> DaughterOrder{0,1};
+        if (mu2->pt()>mu->pt() ){
+	  DaughterOrder.clear();
+      	  DaughterOrder=std::vector<unsigned>({1,0});          
+        }
+        int muOrder=1;
+        for (unsigned i: DaughterOrder){
+          muon_pair.addUserFloat("mu"+std::to_string(muOrder)+"_pt",vtx.daughterP4(i).pt());
+          muon_pair.addUserFloat("mu"+std::to_string(muOrder)+"_eta",vtx.daughterP4(i).eta()); 
+          muon_pair.addUserFloat("mu"+std::to_string(muOrder)+"_phi",vtx.daughterP4(i).phi());
+          muOrder++;
+        }
+
+        //daughter idx
+        if (mu->pt()>mu2->pt() ){
+          muon_pair.addUserInt("mu1_idx",mu-muons->begin());
+          muon_pair.addUserInt("mu2_idx",mu2-muons->begin());
+        } else{
+          muon_pair.addUserInt("mu1_idx",mu2-muons->begin());
+          muon_pair.addUserInt("mu2_idx",mu-muons->begin());
+        }
+
+        // cuts after vertex
+        if ( !post_vtxfit_cuts_(muon_pair) ) continue;
+        pairs->emplace_back(muon_pair);
+
+      }
+    }
+      
+    iEvent.put(std::move(pairs),"diMuons");
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(DiMuonVertexProducer);

--- a/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.cc
+++ b/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.cc
@@ -1,0 +1,37 @@
+#include "SecondaryVertexFitter.h"
+
+
+SecondaryVertexFitter::SecondaryVertexFitter( TransientTrackCollection & ttks_, const std::vector<float> &mass_, bool refit_){
+  mass = mass_;
+  //create vertex
+  KalmanVertexFitter vtxFitter( refit_ );
+  SecVertex=vtxFitter.vertex( ttks_ ); 
+  if (!SecVertex.isValid() ) {m_success=false; return;}
+  m_success=true;
+
+  //refit
+  if ( SecVertex.hasRefittedTracks() && refit_ )
+     KFrefitted=SecVertex.refittedTracks();
+  else
+    KFrefitted=ttks_;  
+
+  // create mother
+  for (reco::TransientTrack & trk: KFrefitted){
+    SVch+=trk.charge();
+    math::PtEtaPhiMLorentzVector vtemp(trk.track().pt(),trk.track().eta(),trk.track().phi(),mass[&trk-&KFrefitted[0]]);
+    SV+=vtemp;
+  }
+ }
+
+SecondaryVertexFitter::~SecondaryVertexFitter() {}
+
+math::PtEtaPhiMLorentzVector
+SecondaryVertexFitter::daughterP4(unsigned int idaughter){
+  return math::PtEtaPhiMLorentzVector(KFrefitted[idaughter].track().pt(),KFrefitted[idaughter].track().eta(),KFrefitted[idaughter].track().phi(),mass[idaughter]);
+}
+
+int
+ SecondaryVertexFitter::daughterCh(unsigned int idaughter){
+  return KFrefitted[idaughter].charge();
+}
+

--- a/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.h
+++ b/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.h
@@ -1,0 +1,76 @@
+// -*- C++ -*-
+// //
+// // Package:    PhysicsTools/NanoAOD
+// // Class:      SecondaryVertexFitter
+// // 
+//
+//  Description: [one line class summary]
+//
+//   Implementation:
+//        [Notes on implementation]
+//        */
+//        //
+//        // Original Author:  George Karathanasis, georgios.karathanasis@cern.ch
+//        //         Created:  Mon, 7 Sep 2019 09:26:39 GMT
+//        //
+//        //
+//
+//
+#ifndef SECONDARYVERTEXFITTER_H
+#define SECONDARYVERTEXFITTER_H
+
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "TLorentzVector.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include <vector>
+
+class SecondaryVertexFitter{
+
+ typedef std::vector<reco::TransientTrack> TransientTrackCollection;
+
+ public: 
+
+  SecondaryVertexFitter() {};
+  SecondaryVertexFitter( TransientTrackCollection & ttks, const std::vector<float> &mass, bool refit_);   
+  virtual ~SecondaryVertexFitter();
+
+  bool success() { return m_success; }
+
+  // mom properties
+  math::PtEtaPhiMLorentzVector motherP4() { return SV; }  
+  int motherCh() { return SVch; }
+
+  //position
+  GlobalPoint motherXYZ(){ return SecVertex.position(); }
+  GlobalError motherXYZError(){ return SecVertex.positionError(); }
+
+  // vertex quality
+  float chi2() { return m_success ? SecVertex.totalChiSquared() : 999; }
+  float dof() { return m_success ? SecVertex.degreesOfFreedom() : -1; }
+  float prob() { return m_success ? ChiSquaredProbability(chi2(), dof()) : 0; }
+
+  // daughter properties
+  math::PtEtaPhiMLorentzVector daughterP4(unsigned int idaughter);
+  int daughterCh(unsigned int idaughter);
+ 
+  
+  
+
+ private:
+  bool m_success; 
+  TransientVertex SecVertex;
+  int SVch=0;
+  TransientTrackCollection KFrefitted;
+  std::vector<float> mass;
+  math::PtEtaPhiMLorentzVector SV;
+
+};
+#endif

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -9,7 +9,13 @@ typedef EventSingletonSimpleFlatTableProducer<GenEventInfoProduct> SimpleGenEven
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 typedef EventSingletonSimpleFlatTableProducer<HTXS::HiggsClassification> SimpleHTXSFlatTableProducer;
 
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+typedef SimpleFlatTableProducer<pat::CompositeCandidate> SimpleCompositeCandidateFlatTableProducer;
+
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenEventFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleHTXSFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleCompositeCandidateFlatTableProducer);
+

--- a/PhysicsTools/NanoAOD/python/dimuons_cff.py
+++ b/PhysicsTools/NanoAOD/python/dimuons_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+
+
+DiMuonVertex = cms.EDProducer("DiMuonVertexProducer",
+    src = cms.InputTag("slimmedMuons"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    mu1Selection = cms.string ("pt>5 && abs(eta)<2.4"),
+    mu2Selection = cms.string ("pt>3 && abs(eta)<2.4"),
+    preVtxSelection = cms.string ("pt>5 && abs(eta)<2.4"),
+    postVtxSelection = cms.string ("userFloat('prob')>0.01"), # WP 0.01
+    RefitTracks = cms.bool (True),
+    FitTunePTransientTracks = cms.bool(True),
+)
+
+DiMuonTable = cms.EDProducer("SimpleCompositeCandidateFlatTableProducer",
+    src = cms.InputTag("DiMuonVertex","diMuons"),
+    cut = cms.string(""), #we should not filter on cross linked collections
+    name = cms.string("DiMuon"),
+    doc  = cms.string("dimuons that create a good vertex"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table for the muons
+    variables = cms.PSet(
+      CandVars,
+      fit_pt = Var("userFloat('fit_pt')",float,doc="fitted pT of dimuon system",precision=12),
+      fit_eta = Var("userFloat('fit_eta')",float,doc="fitted eta of dimuon system",precision=12),     
+      fit_phi = Var("userFloat('fit_phi')",float,doc="fitted phi of dimuon system",precision=12),
+      fit_mass = Var("userFloat('fit_mass')",float,doc="fitted mass of dimuon system",precision=-1),
+      vtx_prob = Var("userFloat('prob')",float,doc="Vertex probability",precision=12),
+      vtx_x = Var("userFloat('vtx_x')",float,doc="x of dimuon vtx",precision=12),
+      vtx_y = Var("userFloat('vtx_y')",float,doc="y of dimuon vtx",precision=12),
+      vtx_z = Var("userFloat('vtx_z')",float,doc="z of dimuon vtx",precision=12),
+      IP_fromBS = Var("userFloat('IP_fromBS')",float,doc="2D impact parameter measured from beamspot",precision=12),
+      SIP_fromBS = Var("userFloat('SIP_fromBS')",float,doc="significance of 2D impact parameter measured from beamspot",precision=12),
+      IP_fromPV = Var("userFloat('IP_fromPV')",float,doc="2D impact parameter measured from primary vertex",precision=12),
+      SIP_fromPV = Var("userFloat('SIP_fromPV')",float,doc="significance of 2D impact parameter measured from primary vertex",precision=12),
+      mu1_idx = Var("userInt('mu1_idx')",int,doc="idx of leading muon"),
+      mu2_idx = Var("userInt('mu2_idx')",int,doc="idx of subleading muon"),
+
+    )
+)

--- a/PhysicsTools/NanoAOD/python/dimuons_cff.py
+++ b/PhysicsTools/NanoAOD/python/dimuons_cff.py
@@ -3,7 +3,7 @@ from PhysicsTools.NanoAOD.common_cff import *
 
 
 DiMuonVertex = cms.EDProducer("DiMuonVertexProducer",
-    src = cms.InputTag("slimmedMuons"),
+    src = cms.InputTag("finalMuons"),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     mu1Selection = cms.string ("pt>5 && abs(eta)<2.4"),

--- a/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
+++ b/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
@@ -290,6 +290,202 @@ namespace HTXS {
     };
   }  // namespace Stage1_1_Fine
 
+  /// Categorization Stage 1.2:
+  /// Three digit integer of format PF
+  /// Where P is a digit representing the process
+  /// F is a unique integer ( F < 99 ) corresponding to each Stage1_2 phase-space region (bin)
+  namespace Stage1_2 {
+    enum Category {
+      UNKNOWN  = 0,
+      // Gluon fusion
+      GG2H_FWDH = 100,
+      GG2H_PTH_200_300 = 101,
+      GG2H_PTH_300_450 = 102,
+      GG2H_PTH_450_650 = 103,
+      GG2H_PTH_GT650 = 104,
+      GG2H_0J_PTH_0_10   = 105,
+      GG2H_0J_PTH_GT10   = 106,
+      GG2H_1J_PTH_0_60 = 107,
+      GG2H_1J_PTH_60_120 = 108,
+      GG2H_1J_PTH_120_200 = 109,
+      GG2H_GE2J_MJJ_0_350_PTH_0_60 = 110,
+      GG2H_GE2J_MJJ_0_350_PTH_60_120 = 111,
+      GG2H_GE2J_MJJ_0_350_PTH_120_200 = 112,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 = 113,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25 = 114,
+      GG2H_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_0_25 = 115,
+      GG2H_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_GT25 = 116,
+      // "VBF"
+      QQ2HQQ_FWDH = 200,
+      QQ2HQQ_0J = 201,
+      QQ2HQQ_1J = 202,
+      QQ2HQQ_GE2J_MJJ_0_60 = 203,
+      QQ2HQQ_GE2J_MJJ_60_120 = 204,
+      QQ2HQQ_GE2J_MJJ_120_350 = 205,
+      QQ2HQQ_GE2J_MJJ_GT350_PTH_GT200 = 206,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 = 207,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25 = 208,
+      QQ2HQQ_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_0_25 = 209,
+      QQ2HQQ_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_GT25 = 210,
+      // qq -> WH
+      QQ2HLNU_FWDH = 300,
+      QQ2HLNU_PTV_0_75 = 301,
+      QQ2HLNU_PTV_75_150 = 302,
+      QQ2HLNU_PTV_150_250_0J = 303,
+      QQ2HLNU_PTV_150_250_GE1J = 304,
+      QQ2HLNU_PTV_GT250 = 305,
+      // qq -> ZH
+      QQ2HLL_FWDH = 400,
+      QQ2HLL_PTV_0_75 = 401,
+      QQ2HLL_PTV_75_150 = 402,
+      QQ2HLL_PTV_150_250_0J = 403,
+      QQ2HLL_PTV_150_250_GE1J = 404,
+      QQ2HLL_PTV_GT250 = 405,
+      // gg -> ZH
+      GG2HLL_FWDH = 500,
+      GG2HLL_PTV_0_75 = 501,
+      GG2HLL_PTV_75_150 = 502,
+      GG2HLL_PTV_150_250_0J = 503,
+      GG2HLL_PTV_150_250_GE1J = 504,
+      GG2HLL_PTV_GT250 = 505,
+      // ttH
+      TTH_FWDH = 600, 
+      TTH_PTH_0_60 = 601,
+      TTH_PTH_60_120 = 602,
+      TTH_PTH_120_200 = 603,
+      TTH_PTH_200_300 = 604,
+      TTH_PTH_GT300 = 605,
+      // bbH
+      BBH_FWDH = 700, BBH = 701,
+      // tH
+      TH_FWDH = 800, TH = 801
+    };
+  } // namespace Stage1_2
+
+  namespace Stage1_2_Fine {
+    enum Category {
+      UNKNOWN  = 0,
+      // Gluon fusion
+      GG2H_FWDH = 100,
+      GG2H_PTH_200_300_PTHJoverPTH_0_15 = 101,
+      GG2H_PTH_300_450_PTHJoverPTH_0_15 = 102,
+      GG2H_PTH_450_650_PTHJoverPTH_0_15 = 103,
+      GG2H_PTH_GT650_PTHJoverPTH_0_15 = 104,
+      GG2H_PTH_200_300_PTHJoverPTH_GT15 = 105,
+      GG2H_PTH_300_450_PTHJoverPTH_GT15 = 106,
+      GG2H_PTH_450_650_PTHJoverPTH_GT15 = 107,
+      GG2H_PTH_GT650_PTHJoverPTH_GT15 = 108,
+      GG2H_0J_PTH_0_10   = 109,
+      GG2H_0J_PTH_GT10   = 110,
+      GG2H_1J_PTH_0_60 = 111,
+      GG2H_1J_PTH_60_120 = 112,
+      GG2H_1J_PTH_120_200 = 113,
+      GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_0_25 = 114,
+      GG2H_GE2J_MJJ_0_350_PTH_60_120_PTHJJ_0_25 = 115,
+      GG2H_GE2J_MJJ_0_350_PTH_120_200_PTHJJ_0_25 = 116,
+      GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_GT25 = 117,
+      GG2H_GE2J_MJJ_0_350_PTH_60_120_PTHJJ_GT25 = 118,
+      GG2H_GE2J_MJJ_0_350_PTH_120_200_PTHJJ_GT25 = 119,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 = 120,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25 = 121,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25 = 122,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25 = 123,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25 = 124,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25 = 125,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25 = 126,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25 = 127,
+      // "VBF"
+      QQ2HQQ_FWDH = 200,
+      QQ2HQQ_0J = 201,
+      QQ2HQQ_1J = 202,
+      QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_0_25 = 203,
+      QQ2HQQ_GE2J_MJJ_60_120_PTHJJ_0_25 = 204,
+      QQ2HQQ_GE2J_MJJ_120_350_PTHJJ_0_25 = 205,
+      QQ2HQQ_GE2J_MJJ_0_60_PTHJJ_GT25 = 206,
+      QQ2HQQ_GE2J_MJJ_60_120_PTHJJ_GT25 = 207,
+      QQ2HQQ_GE2J_MJJ_120_350_PTHJJ_GT25 = 208,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 = 209,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25 = 210,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25 = 211,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25 = 212,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25 = 213,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25 = 214,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25 = 215,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25 = 216,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_GT200_PTHJJ_0_25 = 217,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_GT200_PTHJJ_GT25 = 218,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_GT200_PTHJJ_0_25 = 219,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_GT200_PTHJJ_GT25 = 220,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_GT200_PTHJJ_0_25 = 221,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_GT200_PTHJJ_GT25 = 222,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_GT200_PTHJJ_0_25 = 223,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_GT200_PTHJJ_GT25 = 224,
+      // qq -> WH
+      QQ2HLNU_FWDH = 300,
+      QQ2HLNU_PTV_0_75_0J = 301,
+      QQ2HLNU_PTV_75_150_0J = 302,
+      QQ2HLNU_PTV_150_250_0J = 303,
+      QQ2HLNU_PTV_250_400_0J = 304,
+      QQ2HLNU_PTV_GT400_0J = 305,
+      QQ2HLNU_PTV_0_75_1J = 306,
+      QQ2HLNU_PTV_75_150_1J = 307,
+      QQ2HLNU_PTV_150_250_1J = 308,
+      QQ2HLNU_PTV_250_400_1J = 309,
+      QQ2HLNU_PTV_GT400_1J = 310,
+      QQ2HLNU_PTV_0_75_GE2J = 311,
+      QQ2HLNU_PTV_75_150_GE2J = 312,
+      QQ2HLNU_PTV_150_250_GE2J = 313,
+      QQ2HLNU_PTV_250_400_GE2J = 314,
+      QQ2HLNU_PTV_GT400_GE2J = 315,
+      // qq -> ZH
+      QQ2HLL_FWDH = 400,
+      QQ2HLL_PTV_0_75_0J = 401,
+      QQ2HLL_PTV_75_150_0J = 402,
+      QQ2HLL_PTV_150_250_0J = 403,
+      QQ2HLL_PTV_250_400_0J = 404,
+      QQ2HLL_PTV_GT400_0J = 405,
+      QQ2HLL_PTV_0_75_1J = 406,
+      QQ2HLL_PTV_75_150_1J = 407,
+      QQ2HLL_PTV_150_250_1J = 408,
+      QQ2HLL_PTV_250_400_1J = 409,
+      QQ2HLL_PTV_GT400_1J = 410,
+      QQ2HLL_PTV_0_75_GE2J = 411,
+      QQ2HLL_PTV_75_150_GE2J = 412,
+      QQ2HLL_PTV_150_250_GE2J = 413,
+      QQ2HLL_PTV_250_400_GE2J = 414,
+      QQ2HLL_PTV_GT400_GE2J = 415,
+      // gg -> ZH
+      GG2HLL_FWDH = 500,
+      GG2HLL_PTV_0_75_0J = 501,
+      GG2HLL_PTV_75_150_0J = 502,
+      GG2HLL_PTV_150_250_0J = 503,
+      GG2HLL_PTV_250_400_0J = 504,
+      GG2HLL_PTV_GT400_0J = 505,
+      GG2HLL_PTV_0_75_1J = 506,
+      GG2HLL_PTV_75_150_1J = 507,
+      GG2HLL_PTV_150_250_1J = 508,
+      GG2HLL_PTV_250_400_1J = 509,
+      GG2HLL_PTV_GT400_1J = 510,
+      GG2HLL_PTV_0_75_GE2J = 511,
+      GG2HLL_PTV_75_150_GE2J = 512,
+      GG2HLL_PTV_150_250_GE2J = 513,
+      GG2HLL_PTV_250_400_GE2J = 514,
+      GG2HLL_PTV_GT400_GE2J = 515,
+      // ttH
+      TTH_FWDH = 600, 
+      TTH_PTH_0_60 = 601,
+      TTH_PTH_60_120 = 602,
+      TTH_PTH_120_200 = 603,
+      TTH_PTH_200_300 = 604,
+      TTH_PTH_300_450 = 605,
+      TTH_PTH_GT450 = 606,
+      // bbH
+      BBH_FWDH = 700, BBH = 701,
+      // tH
+      TH_FWDH = 800, TH = 801
+    };
+  } // namespace Stage1_2_Fine
+
   //#ifdef ROOT_TLorentzVector
   //typedef TLorentzVector TLV;
   typedef math::XYZTLorentzVectorD TLV;
@@ -334,6 +530,12 @@ namespace HTXS {
     HTXS::Stage1_1::Category stage1_1_cat_pTjet30GeV;
     HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet25GeV;
     HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet30GeV;
+    HTXS::Stage1_2::Category stage1_2_cat_pTjet25GeV;
+    HTXS::Stage1_2::Category stage1_2_cat_pTjet30GeV;
+    HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet25GeV;
+    HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet30GeV;
+    // Flag for Z->vv decay mode (needed to split QQ2ZH and GG2ZH)
+    bool isZ2vvDecay;
     // Error code :: classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };
@@ -356,6 +558,11 @@ namespace HTXS {
     cat.stage1_1_cat_pTjet30GeV = htxs_cat_rivet.stage1_1_cat_pTjet30GeV;
     cat.stage1_1_fine_cat_pTjet25GeV = htxs_cat_rivet.stage1_1_fine_cat_pTjet25GeV;
     cat.stage1_1_fine_cat_pTjet30GeV = htxs_cat_rivet.stage1_1_fine_cat_pTjet30GeV;
+    cat.stage1_2_cat_pTjet25GeV = htxs_cat_rivet.stage1_2_cat_pTjet25GeV;
+    cat.stage1_2_cat_pTjet30GeV = htxs_cat_rivet.stage1_2_cat_pTjet30GeV;
+    cat.stage1_2_fine_cat_pTjet25GeV = htxs_cat_rivet.stage1_2_fine_cat_pTjet25GeV;
+    cat.stage1_2_fine_cat_pTjet30GeV = htxs_cat_rivet.stage1_2_fine_cat_pTjet30GeV;
+    cat.isZ2vvDecay = htxs_cat_rivet.isZ2vvDecay;
     return cat;
   }
 
@@ -403,6 +610,100 @@ namespace HTXS {
     return (F + offset[P]);
   }
 
+  inline int HTXSstage1_2_to_HTXSstage1_2_FineIndex(HTXS::Stage1_2::Category stage1_2,
+				 HiggsProdMode prodMode, tH_type tH) {
+
+    if(stage1_2==HTXS::Stage1_2::Category::UNKNOWN) return 0;
+    int P = (int)(stage1_2 / 100);
+    int F = (int)(stage1_2 % 100);
+    // 1.a spit tH categories
+    if (prodMode==HiggsProdMode::TH) {
+        // check that tH splitting is valid for Stage-1 FineIndex
+	// else return unknown category
+        if(tH==tH_type::noTH) return 0;
+	// check if forward tH
+	int fwdH = F==0?0:1;
+        return (94 + 2*(tH-1) +fwdH);
+    }
+    // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
+    // offset vector 1: input is the Higgs prodMode 
+    // first two indicies are dummies, given that this is only called for prodMode=2,3,4 
+    std::vector<int> pMode_offset = {0,0,35,46,57};
+    if (P==2) return (F + pMode_offset[prodMode]);
+    // 1.c GG2ZH split into gg->ZH-had and gg->ZH-lep
+    if (prodMode==HiggsProdMode::GG2ZH && P==1) return F + 18;
+    // 1.d remaining categories
+    // offset vector 2: input is the Stage-1 category P 
+    // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
+    std::vector<int> catP_offset =   {0,1,0,68,74,80,86,92};
+    return (F + catP_offset[P]);
+  }
+
+  inline int HTXSstage1_2_to_HTXSstage1_2_FineIndex(const HiggsClassification &stxs,
+				 tH_type tH=noTH, bool jets_pT25 = false) {
+    HTXS::Stage1_2::Category stage1_2 =
+    jets_pT25==false?stxs.stage1_2_cat_pTjet30GeV:
+    stxs.stage1_2_cat_pTjet25GeV;
+    return HTXSstage1_2_to_HTXSstage1_2_FineIndex(stage1_2,stxs.prodMode,tH);
+  }
+    
+  inline int HTXSstage1_2_to_index(HTXS::Stage1_2::Category stage1_2) {
+    // the Stage-1 categories
+    int P = (int)(stage1_2 / 100);
+    int F = (int)(stage1_2 % 100);
+    //std::vector<int> offset{0,1,13,19,24,29,33,35,37,39};
+    std::vector<int> offset{0,1,18,29,35,41,47,53,55,57};
+    // convert to linear values
+    return ( F + offset[P] );
+    }
+
+    //Same for Stage1_2_Fine categories
+  inline int HTXSstage1_2_Fine_to_HTXSstage1_2_Fine_FineIndex(HTXS::Stage1_2_Fine::Category Stage1_2_Fine,
+                       HiggsProdMode prodMode, tH_type tH) {
+
+    if(Stage1_2_Fine==HTXS::Stage1_2_Fine::Category::UNKNOWN) return 0;
+    int P = (int)(Stage1_2_Fine / 100);
+    int F = (int)(Stage1_2_Fine % 100);
+    // 1.a spit tH categories
+    if (prodMode==HiggsProdMode::TH) {
+    // check that tH splitting is valid for Stage-1 FineIndex
+    // else return unknown category
+    if(tH==tH_type::noTH) return 0;
+    // check if forward tH
+    int fwdH = F==0?0:1;
+    return (189 + 2*(tH-1) +fwdH);
+    }
+    // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
+    // offset vector 1: input is the Higgs prodMode
+    // first two indicies are dummies, given that this is only called for prodMode=2,3,4
+    std::vector<int> pMode_offset = {0,0,57,82,107};
+    if (P==2) return (F + pMode_offset[prodMode]);
+    // 1.c GG2ZH split into gg->ZH-had and gg->ZH-lep
+    if (prodMode==HiggsProdMode::GG2ZH && P==1) return F + 29;
+    // 1.d remaining categories
+    // offset vector 2: input is the Stage-1 category P
+    // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
+    std::vector<int> catP_offset = {0,1,0,132,148,164,180,187};
+    return (F + catP_offset[P]);
+  }
+
+  inline int HTXSstage1_2_Fine_to_HTXSstage1_2_Fine_FineIndex(const HiggsClassification &stxs,
+                       tH_type tH=noTH, bool jets_pT25 = false) {
+    HTXS::Stage1_2_Fine::Category Stage1_2_Fine =
+  jets_pT25==false?stxs.stage1_2_fine_cat_pTjet30GeV:
+  stxs.stage1_2_fine_cat_pTjet25GeV;
+    return HTXSstage1_2_Fine_to_HTXSstage1_2_Fine_FineIndex(Stage1_2_Fine,stxs.prodMode,tH);
+  }
+
+  inline int HTXSstage1_2_Fine_to_index(HTXS::Stage1_2_Fine::Category Stage1_2_Fine) {
+    // the Stage-1_2_Fine categories
+    int P = (int)(Stage1_2_Fine / 100);
+    int F = (int)(Stage1_2_Fine % 100);
+    std::vector<int> offset{0,1,29,54,70,86,102,109,111,113};
+    // convert to linear values
+    return ( F + offset[P] );
+    }
+
   // #endif
 
 }  // namespace HTXS
@@ -443,6 +744,16 @@ namespace Rivet {
     HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet25GeV;
     /// Stage-1_1 STXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS#Stage_1_1
     HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet30GeV;
+    /// Stage-1 STXS event classifcation, see: https://cds.cern.ch/record/2138079
+    HTXS::Stage1_2::Category stage1_2_cat_pTjet25GeV;
+    /// Stage-1 STXS event classifcation, see: https://cds.cern.ch/record/2138079
+    HTXS::Stage1_2::Category stage1_2_cat_pTjet30GeV;
+    /// Stage-1_2 STXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS#Stage_1_1
+    HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet25GeV;
+    /// Stage-1_2 STXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS#Stage_1_1
+    HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet30GeV;
+    /// Flag to distiguish the Z->vv and Z->l+l- decay modes
+    bool isZ2vvDecay;
     /// Error code: Whether classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };

--- a/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
+++ b/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
@@ -296,15 +296,15 @@ namespace HTXS {
   /// F is a unique integer ( F < 99 ) corresponding to each Stage1_2 phase-space region (bin)
   namespace Stage1_2 {
     enum Category {
-      UNKNOWN  = 0,
+      UNKNOWN = 0,
       // Gluon fusion
       GG2H_FWDH = 100,
       GG2H_PTH_200_300 = 101,
       GG2H_PTH_300_450 = 102,
       GG2H_PTH_450_650 = 103,
       GG2H_PTH_GT650 = 104,
-      GG2H_0J_PTH_0_10   = 105,
-      GG2H_0J_PTH_GT10   = 106,
+      GG2H_0J_PTH_0_10 = 105,
+      GG2H_0J_PTH_GT10 = 106,
       GG2H_1J_PTH_0_60 = 107,
       GG2H_1J_PTH_60_120 = 108,
       GG2H_1J_PTH_120_200 = 109,
@@ -349,22 +349,24 @@ namespace HTXS {
       GG2HLL_PTV_150_250_GE1J = 504,
       GG2HLL_PTV_GT250 = 505,
       // ttH
-      TTH_FWDH = 600, 
+      TTH_FWDH = 600,
       TTH_PTH_0_60 = 601,
       TTH_PTH_60_120 = 602,
       TTH_PTH_120_200 = 603,
       TTH_PTH_200_300 = 604,
       TTH_PTH_GT300 = 605,
       // bbH
-      BBH_FWDH = 700, BBH = 701,
+      BBH_FWDH = 700,
+      BBH = 701,
       // tH
-      TH_FWDH = 800, TH = 801
+      TH_FWDH = 800,
+      TH = 801
     };
-  } // namespace Stage1_2
+  }  // namespace Stage1_2
 
   namespace Stage1_2_Fine {
     enum Category {
-      UNKNOWN  = 0,
+      UNKNOWN = 0,
       // Gluon fusion
       GG2H_FWDH = 100,
       GG2H_PTH_200_300_PTHJoverPTH_0_15 = 101,
@@ -375,8 +377,8 @@ namespace HTXS {
       GG2H_PTH_300_450_PTHJoverPTH_GT15 = 106,
       GG2H_PTH_450_650_PTHJoverPTH_GT15 = 107,
       GG2H_PTH_GT650_PTHJoverPTH_GT15 = 108,
-      GG2H_0J_PTH_0_10   = 109,
-      GG2H_0J_PTH_GT10   = 110,
+      GG2H_0J_PTH_0_10 = 109,
+      GG2H_0J_PTH_GT10 = 110,
       GG2H_1J_PTH_0_60 = 111,
       GG2H_1J_PTH_60_120 = 112,
       GG2H_1J_PTH_120_200 = 113,
@@ -472,7 +474,7 @@ namespace HTXS {
       GG2HLL_PTV_250_400_GE2J = 514,
       GG2HLL_PTV_GT400_GE2J = 515,
       // ttH
-      TTH_FWDH = 600, 
+      TTH_FWDH = 600,
       TTH_PTH_0_60 = 601,
       TTH_PTH_60_120 = 602,
       TTH_PTH_120_200 = 603,
@@ -480,11 +482,13 @@ namespace HTXS {
       TTH_PTH_300_450 = 605,
       TTH_PTH_GT450 = 606,
       // bbH
-      BBH_FWDH = 700, BBH = 701,
+      BBH_FWDH = 700,
+      BBH = 701,
       // tH
-      TH_FWDH = 800, TH = 801
+      TH_FWDH = 800,
+      TH = 801
     };
-  } // namespace Stage1_2_Fine
+  }  // namespace Stage1_2_Fine
 
   //#ifdef ROOT_TLorentzVector
   //typedef TLorentzVector TLV;
@@ -611,98 +615,106 @@ namespace HTXS {
   }
 
   inline int HTXSstage1_2_to_HTXSstage1_2_FineIndex(HTXS::Stage1_2::Category stage1_2,
-				 HiggsProdMode prodMode, tH_type tH) {
-
-    if(stage1_2==HTXS::Stage1_2::Category::UNKNOWN) return 0;
+                                                    HiggsProdMode prodMode,
+                                                    tH_type tH) {
+    if (stage1_2 == HTXS::Stage1_2::Category::UNKNOWN)
+      return 0;
     int P = (int)(stage1_2 / 100);
     int F = (int)(stage1_2 % 100);
     // 1.a spit tH categories
-    if (prodMode==HiggsProdMode::TH) {
-        // check that tH splitting is valid for Stage-1 FineIndex
-	// else return unknown category
-        if(tH==tH_type::noTH) return 0;
-	// check if forward tH
-	int fwdH = F==0?0:1;
-        return (94 + 2*(tH-1) +fwdH);
+    if (prodMode == HiggsProdMode::TH) {
+      // check that tH splitting is valid for Stage-1 FineIndex
+      // else return unknown category
+      if (tH == tH_type::noTH)
+        return 0;
+      // check if forward tH
+      int fwdH = F == 0 ? 0 : 1;
+      return (94 + 2 * (tH - 1) + fwdH);
     }
     // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
-    // offset vector 1: input is the Higgs prodMode 
-    // first two indicies are dummies, given that this is only called for prodMode=2,3,4 
-    std::vector<int> pMode_offset = {0,0,35,46,57};
-    if (P==2) return (F + pMode_offset[prodMode]);
+    // offset vector 1: input is the Higgs prodMode
+    // first two indicies are dummies, given that this is only called for prodMode=2,3,4
+    std::vector<int> pMode_offset = {0, 0, 35, 46, 57};
+    if (P == 2)
+      return (F + pMode_offset[prodMode]);
     // 1.c GG2ZH split into gg->ZH-had and gg->ZH-lep
-    if (prodMode==HiggsProdMode::GG2ZH && P==1) return F + 18;
+    if (prodMode == HiggsProdMode::GG2ZH && P == 1)
+      return F + 18;
     // 1.d remaining categories
-    // offset vector 2: input is the Stage-1 category P 
+    // offset vector 2: input is the Stage-1 category P
     // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
-    std::vector<int> catP_offset =   {0,1,0,68,74,80,86,92};
+    std::vector<int> catP_offset = {0, 1, 0, 68, 74, 80, 86, 92};
     return (F + catP_offset[P]);
   }
 
   inline int HTXSstage1_2_to_HTXSstage1_2_FineIndex(const HiggsClassification &stxs,
-				 tH_type tH=noTH, bool jets_pT25 = false) {
+                                                    tH_type tH = noTH,
+                                                    bool jets_pT25 = false) {
     HTXS::Stage1_2::Category stage1_2 =
-    jets_pT25==false?stxs.stage1_2_cat_pTjet30GeV:
-    stxs.stage1_2_cat_pTjet25GeV;
-    return HTXSstage1_2_to_HTXSstage1_2_FineIndex(stage1_2,stxs.prodMode,tH);
+        jets_pT25 == false ? stxs.stage1_2_cat_pTjet30GeV : stxs.stage1_2_cat_pTjet25GeV;
+    return HTXSstage1_2_to_HTXSstage1_2_FineIndex(stage1_2, stxs.prodMode, tH);
   }
-    
+
   inline int HTXSstage1_2_to_index(HTXS::Stage1_2::Category stage1_2) {
     // the Stage-1 categories
     int P = (int)(stage1_2 / 100);
     int F = (int)(stage1_2 % 100);
     //std::vector<int> offset{0,1,13,19,24,29,33,35,37,39};
-    std::vector<int> offset{0,1,18,29,35,41,47,53,55,57};
+    std::vector<int> offset{0, 1, 18, 29, 35, 41, 47, 53, 55, 57};
     // convert to linear values
-    return ( F + offset[P] );
-    }
+    return (F + offset[P]);
+  }
 
-    //Same for Stage1_2_Fine categories
+  //Same for Stage1_2_Fine categories
   inline int HTXSstage1_2_Fine_to_HTXSstage1_2_Fine_FineIndex(HTXS::Stage1_2_Fine::Category Stage1_2_Fine,
-                       HiggsProdMode prodMode, tH_type tH) {
-
-    if(Stage1_2_Fine==HTXS::Stage1_2_Fine::Category::UNKNOWN) return 0;
+                                                              HiggsProdMode prodMode,
+                                                              tH_type tH) {
+    if (Stage1_2_Fine == HTXS::Stage1_2_Fine::Category::UNKNOWN)
+      return 0;
     int P = (int)(Stage1_2_Fine / 100);
     int F = (int)(Stage1_2_Fine % 100);
     // 1.a spit tH categories
-    if (prodMode==HiggsProdMode::TH) {
-    // check that tH splitting is valid for Stage-1 FineIndex
-    // else return unknown category
-    if(tH==tH_type::noTH) return 0;
-    // check if forward tH
-    int fwdH = F==0?0:1;
-    return (189 + 2*(tH-1) +fwdH);
+    if (prodMode == HiggsProdMode::TH) {
+      // check that tH splitting is valid for Stage-1 FineIndex
+      // else return unknown category
+      if (tH == tH_type::noTH)
+        return 0;
+      // check if forward tH
+      int fwdH = F == 0 ? 0 : 1;
+      return (189 + 2 * (tH - 1) + fwdH);
     }
     // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
     // offset vector 1: input is the Higgs prodMode
     // first two indicies are dummies, given that this is only called for prodMode=2,3,4
-    std::vector<int> pMode_offset = {0,0,57,82,107};
-    if (P==2) return (F + pMode_offset[prodMode]);
+    std::vector<int> pMode_offset = {0, 0, 57, 82, 107};
+    if (P == 2)
+      return (F + pMode_offset[prodMode]);
     // 1.c GG2ZH split into gg->ZH-had and gg->ZH-lep
-    if (prodMode==HiggsProdMode::GG2ZH && P==1) return F + 29;
+    if (prodMode == HiggsProdMode::GG2ZH && P == 1)
+      return F + 29;
     // 1.d remaining categories
     // offset vector 2: input is the Stage-1 category P
     // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
-    std::vector<int> catP_offset = {0,1,0,132,148,164,180,187};
+    std::vector<int> catP_offset = {0, 1, 0, 132, 148, 164, 180, 187};
     return (F + catP_offset[P]);
   }
 
   inline int HTXSstage1_2_Fine_to_HTXSstage1_2_Fine_FineIndex(const HiggsClassification &stxs,
-                       tH_type tH=noTH, bool jets_pT25 = false) {
+                                                              tH_type tH = noTH,
+                                                              bool jets_pT25 = false) {
     HTXS::Stage1_2_Fine::Category Stage1_2_Fine =
-  jets_pT25==false?stxs.stage1_2_fine_cat_pTjet30GeV:
-  stxs.stage1_2_fine_cat_pTjet25GeV;
-    return HTXSstage1_2_Fine_to_HTXSstage1_2_Fine_FineIndex(Stage1_2_Fine,stxs.prodMode,tH);
+        jets_pT25 == false ? stxs.stage1_2_fine_cat_pTjet30GeV : stxs.stage1_2_fine_cat_pTjet25GeV;
+    return HTXSstage1_2_Fine_to_HTXSstage1_2_Fine_FineIndex(Stage1_2_Fine, stxs.prodMode, tH);
   }
 
   inline int HTXSstage1_2_Fine_to_index(HTXS::Stage1_2_Fine::Category Stage1_2_Fine) {
     // the Stage-1_2_Fine categories
     int P = (int)(Stage1_2_Fine / 100);
     int F = (int)(Stage1_2_Fine % 100);
-    std::vector<int> offset{0,1,29,54,70,86,102,109,111,113};
+    std::vector<int> offset{0, 1, 29, 54, 70, 86, 102, 109, 111, 113};
     // convert to linear values
-    return ( F + offset[P] );
-    }
+    return (F + offset[P]);
+  }
 
   // #endif
 


### PR DESCRIPTION
Dear all,

This PR is adding a dimuon vertex to the NanoAOD output. It is needed in the Muon POG and also will be useful for several analysis.  I have tested that the code works locally and in CRAB  in CMSSW 10 2 16UL. 
Also I tested locally in CMSSW 11 0 pre13. It runs without issues. Cuts can be easily tuned. I attach also the presentation for the muon POG. Unfortunately I see that this PR seems to also try to include some files that I did not touch. I think this is from this "git cms-merge-topic 28444" [it is in the instructions]. Thanks.

Best regards,
George



[DimuonVtx.pdf](https://github.com/cms-nanoAOD/cmssw/files/4114314/DimuonVtx.pdf)
