### PR TITLE
updating dimuon vertex for nanoAOD PR

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -19,6 +19,8 @@
 <use   name="CondTools/BTau"/>
 <use   name="fastjet"/>
 <use   name="fastjet-contrib"/>
+<use   name="RecoVertex/KalmanVertexFit"/>
+<use   name="MagneticField/Records"/>
 <library   file="*.cc" name="PhysicsToolsNanoAODPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/PhysicsTools/NanoAOD/plugins/DiMuonVertexProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/DiMuonVertexProducer.cc
@@ -1,0 +1,221 @@
+// -*- C++ -*-
+//
+// Package:    PhysicsTools/NanoAOD
+// Class:      DiMuonVertexProducer
+// 
+/*
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  George Karathanasis georgios.karathanasis@cern.ch
+//         Created:  Mon, 7 Dec 2019 09:26:39 GMT
+//
+//
+
+
+
+// system include files
+#include <memory>
+#include <sstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/Common/interface/View.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
+#include "PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.h"
+
+
+
+constexpr float MUON_MASS= 0.105;
+
+typedef std::vector<reco::TransientTrack> TransientTrackCollection;
+typedef std::vector<pat::CompositeCandidate> CompositeCandidateCollection;
+
+
+class DiMuonVertexProducer : public edm::stream::EDProducer<> {
+
+  public:
+     explicit DiMuonVertexProducer(const edm::ParameterSet &iConfig) :
+       muons_(consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("muons"))),
+       bspot_{consumes<reco::BeamSpot>( iConfig.getParameter<edm::InputTag>("beamSpot") )},
+       pvs_{consumes< std::vector<reco::Vertex> >( iConfig.getParameter<edm::InputTag>("vertices") )},
+       mu1_cuts_{iConfig.getParameter<std::string>("mu1Selection")},
+       mu2_cuts_{iConfig.getParameter<std::string>("mu2Selection")},
+       pre_vtxfit_cuts_{iConfig.getParameter<std::string>("preVtxSelection")},
+       post_vtxfit_cuts_{iConfig.getParameter<std::string>("postVtxSelection")},
+       refit_{iConfig.getParameter<bool>("RefitTracks")},
+       fitTunePTransientTracks_{iConfig.getParameter<bool>("FitTunePTransientTracks")}
+       {       
+          produces<pat::CompositeCandidateCollection>("diMuons");
+       }
+
+        ~DiMuonVertexProducer() override {}
+
+    private:
+        void produce(edm::Event&, edm::EventSetup const&) override ;
+
+        const edm::EDGetTokenT<edm::View<pat::Muon>> muons_;
+        const edm::EDGetTokenT<reco::BeamSpot> bspot_; 
+        const edm::EDGetTokenT<std::vector<reco::Vertex>> pvs_;
+        const StringCutObjectSelector<pat::Muon> mu1_cuts_;
+        const StringCutObjectSelector<pat::Muon> mu2_cuts_;
+        const StringCutObjectSelector<pat::CompositeCandidate> pre_vtxfit_cuts_;
+        const StringCutObjectSelector<pat::CompositeCandidate> post_vtxfit_cuts_;        
+        bool refit_;
+        bool fitTunePTransientTracks_=false;
+              
+};
+
+// ------------ method called to produce the data  ------------
+void
+DiMuonVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
+{
+   
+    edm::Handle<edm::View<pat::Muon>> muons;
+    iEvent.getByToken(muons_, muons);
+    edm::Handle<reco::BeamSpot> bspot;
+    iEvent.getByToken(bspot_, bspot);  
+    edm::Handle<std::vector<reco::Vertex>> pvs;
+    iEvent.getByToken(pvs_, pvs);  
+
+    edm::ESHandle<MagneticField> bFieldHandle;
+    iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
+     
+    std::unique_ptr<pat::CompositeCandidateCollection> pairs(new pat::CompositeCandidateCollection());
+    math::XYZPoint pv = (pvs->front()).position();
+
+    // muon pair creation 
+    for( edm::View<pat::Muon>::const_iterator mu= muons->begin(); mu!=muons->end(); ++mu){
+      // remove mu not qualified for trailing mu
+      if ( !mu2_cuts_(*mu) ) continue;
+
+      for( edm::View<pat::Muon>::const_iterator mu2= mu+1; mu2!=muons->end(); ++mu2){
+        // remove mu not qualified for trailing mu
+        if ( !mu2_cuts_(*mu2) ) continue;
+         // remove mu not qualified for leading mu        
+        if ( !mu1_cuts_(*mu) && !mu1_cuts_(*mu2) ) continue;
+
+        //create pair
+        pat::CompositeCandidate muon_pair;
+        muon_pair.setP4(mu->p4() + mu2->p4());
+        muon_pair.setCharge(mu->charge() + mu2->charge());
+        muon_pair.addUserFloat("deltaR", reco::deltaR(*mu, *mu2));
+
+        // cut before vertex
+        if ( !pre_vtxfit_cuts_(muon_pair) ) continue;
+        reco::TransientTrack tranmu1((*(mu->bestTrack())), &(*bFieldHandle));
+        reco::TransientTrack tranmu2((*(mu2->bestTrack())), &(*bFieldHandle));
+
+        if(fitTunePTransientTracks_){
+          tranmu1=reco::TransientTrack((*(mu->tunePMuonBestTrack() )), &(*bFieldHandle));
+          tranmu2=reco::TransientTrack((*(mu2->tunePMuonBestTrack() )), &(*bFieldHandle));
+        }
+
+        //fit
+        TransientTrackCollection mutrk{ tranmu1, tranmu2};
+        SecondaryVertexFitter vtx(mutrk,{MUON_MASS,MUON_MASS},refit_);
+
+        // remove failures
+        if ( !vtx.success() ) continue;
+
+        //pair after fit
+        muon_pair.addUserFloat("fit_pt",vtx.motherP4().pt());
+        muon_pair.addUserFloat("fit_eta",vtx.motherP4().eta());
+        muon_pair.addUserFloat("fit_phi",vtx.motherP4().phi());
+        muon_pair.addUserFloat("fit_mass",vtx.motherP4().mass());
+        muon_pair.addUserFloat("fit_charge",vtx.motherCh());
+
+        //vertex quality
+        muon_pair.addUserFloat("chi2",vtx.chi2());
+        muon_pair.addUserFloat("dof",vtx.dof());
+        muon_pair.addUserFloat("prob",vtx.prob());
+
+        //vertex position
+        muon_pair.addUserFloat("vtx_x",vtx.motherXYZ().x());
+        muon_pair.addUserFloat("vtx_y",vtx.motherXYZ().y());
+        muon_pair.addUserFloat("vtx_z",vtx.motherXYZ().z());
+
+        //distance variables
+	GlobalPoint Dispbeamspot(
+				 -1*((bspot->x0()-vtx.motherXYZ().x())+(vtx.motherXYZ().z()-bspot->z0())* bspot->dxdz()),
+				 -1*((bspot->y0()-vtx.motherXYZ().y())+ (vtx.motherXYZ().z()-bspot->z0()) * bspot->dydz()), 0);
+
+        float Lxy = Dispbeamspot.perp();  
+        float eLxy= vtx.motherXYZError().rerr(Dispbeamspot); 
+        eLxy = TMath::Sqrt( eLxy );
+
+        muon_pair.addUserFloat("IP_fromBS",Lxy);
+        muon_pair.addUserFloat("EIP_fromBS",eLxy);
+        muon_pair.addUserFloat("SIP_fromBS",eLxy !=0 ? Lxy/eLxy : 0);
+	
+        GlobalPoint DispFromPV(
+			        pv.x()-vtx.motherXYZ().x(),
+			        pv.y()-vtx.motherXYZ().y(), 
+                                0 
+                               );
+
+        float LxyPV = DispFromPV.perp();  
+        float eLxyPV= vtx.motherXYZError().rerr(DispFromPV); 
+        eLxyPV = TMath::Sqrt( eLxyPV );
+
+        muon_pair.addUserFloat("IP_fromPV",LxyPV);
+        muon_pair.addUserFloat("EIP_fromPV",eLxyPV);
+        muon_pair.addUserFloat("SIP_fromPV",eLxyPV != 0 ? LxyPV/eLxyPV : 0);
+
+        //daughter refited
+	std::vector<unsigned> DaughterOrder{0,1};
+        if (mu2->pt()>mu->pt() ){
+	  DaughterOrder.clear();
+      	  DaughterOrder=std::vector<unsigned>({1,0});          
+        }
+        int muOrder=1;
+        for (unsigned i: DaughterOrder){
+          muon_pair.addUserFloat("mu"+std::to_string(muOrder)+"_pt",vtx.daughterP4(i).pt());
+          muon_pair.addUserFloat("mu"+std::to_string(muOrder)+"_eta",vtx.daughterP4(i).eta()); 
+          muon_pair.addUserFloat("mu"+std::to_string(muOrder)+"_phi",vtx.daughterP4(i).phi());
+          muOrder++;
+        }
+
+        //daughter idx
+        if (mu->pt()>mu2->pt() ){
+          muon_pair.addUserInt("mu1_idx",mu-muons->begin());
+          muon_pair.addUserInt("mu2_idx",mu2-muons->begin());
+        } else{
+          muon_pair.addUserInt("mu1_idx",mu2-muons->begin());
+          muon_pair.addUserInt("mu2_idx",mu-muons->begin());
+        }
+
+        // cuts after vertex
+        if ( !post_vtxfit_cuts_(muon_pair) ) continue;
+        pairs->emplace_back(muon_pair);
+
+      }
+    }
+      
+    iEvent.put(std::move(pairs),"diMuons");
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(DiMuonVertexProducer);

--- a/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.cc
+++ b/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.cc
@@ -1,0 +1,37 @@
+#include "SecondaryVertexFitter.h"
+
+
+SecondaryVertexFitter::SecondaryVertexFitter( TransientTrackCollection & ttks_, const std::vector<float> &mass_, bool refit_){
+  mass = mass_;
+  //create vertex
+  KalmanVertexFitter vtxFitter( refit_ );
+  SecVertex=vtxFitter.vertex( ttks_ ); 
+  if (!SecVertex.isValid() ) {m_success=false; return;}
+  m_success=true;
+
+  //refit
+  if ( SecVertex.hasRefittedTracks() && refit_ )
+     KFrefitted=SecVertex.refittedTracks();
+  else
+    KFrefitted=ttks_;  
+
+  // create mother
+  for (reco::TransientTrack & trk: KFrefitted){
+    SVch+=trk.charge();
+    math::PtEtaPhiMLorentzVector vtemp(trk.track().pt(),trk.track().eta(),trk.track().phi(),mass[&trk-&KFrefitted[0]]);
+    SV+=vtemp;
+  }
+ }
+
+SecondaryVertexFitter::~SecondaryVertexFitter() {}
+
+math::PtEtaPhiMLorentzVector
+SecondaryVertexFitter::daughterP4(unsigned int idaughter){
+  return math::PtEtaPhiMLorentzVector(KFrefitted[idaughter].track().pt(),KFrefitted[idaughter].track().eta(),KFrefitted[idaughter].track().phi(),mass[idaughter]);
+}
+
+int
+ SecondaryVertexFitter::daughterCh(unsigned int idaughter){
+  return KFrefitted[idaughter].charge();
+}
+

--- a/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.h
+++ b/PhysicsTools/NanoAOD/plugins/SecondaryVertexFitter.h
@@ -1,0 +1,76 @@
+// -*- C++ -*-
+// //
+// // Package:    PhysicsTools/NanoAOD
+// // Class:      SecondaryVertexFitter
+// // 
+//
+//  Description: [one line class summary]
+//
+//   Implementation:
+//        [Notes on implementation]
+//        */
+//        //
+//        // Original Author:  George Karathanasis, georgios.karathanasis@cern.ch
+//        //         Created:  Mon, 7 Sep 2019 09:26:39 GMT
+//        //
+//        //
+//
+//
+#ifndef SECONDARYVERTEXFITTER_H
+#define SECONDARYVERTEXFITTER_H
+
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "TLorentzVector.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include <vector>
+
+class SecondaryVertexFitter{
+
+ typedef std::vector<reco::TransientTrack> TransientTrackCollection;
+
+ public: 
+
+  SecondaryVertexFitter() {};
+  SecondaryVertexFitter( TransientTrackCollection & ttks, const std::vector<float> &mass, bool refit_);   
+  virtual ~SecondaryVertexFitter();
+
+  bool success() { return m_success; }
+
+  // mom properties
+  math::PtEtaPhiMLorentzVector motherP4() { return SV; }  
+  int motherCh() { return SVch; }
+
+  //position
+  GlobalPoint motherXYZ(){ return SecVertex.position(); }
+  GlobalError motherXYZError(){ return SecVertex.positionError(); }
+
+  // vertex quality
+  float chi2() { return m_success ? SecVertex.totalChiSquared() : 999; }
+  float dof() { return m_success ? SecVertex.degreesOfFreedom() : -1; }
+  float prob() { return m_success ? ChiSquaredProbability(chi2(), dof()) : 0; }
+
+  // daughter properties
+  math::PtEtaPhiMLorentzVector daughterP4(unsigned int idaughter);
+  int daughterCh(unsigned int idaughter);
+ 
+  
+  
+
+ private:
+  bool m_success; 
+  TransientVertex SecVertex;
+  int SVch=0;
+  TransientTrackCollection KFrefitted;
+  std::vector<float> mass;
+  math::PtEtaPhiMLorentzVector SV;
+
+};
+#endif

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -9,7 +9,11 @@ typedef EventSingletonSimpleFlatTableProducer<GenEventInfoProduct> SimpleGenEven
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 typedef EventSingletonSimpleFlatTableProducer<HTXS::HiggsClassification> SimpleHTXSFlatTableProducer;
 
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+typedef SimpleFlatTableProducer<pat::CompositeCandidate> SimpleCompositeCandidateFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenEventFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleHTXSFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleCompositeCandidateFlatTableProducer);

--- a/PhysicsTools/NanoAOD/python/dimuons_cff.py
+++ b/PhysicsTools/NanoAOD/python/dimuons_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+
+
+DiMuonVertex = cms.EDProducer("DiMuonVertexProducer",
+    muons = cms.InputTag("finalMuons"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    mu1Selection = cms.string ("pt>5 && abs(eta)<2.4"),
+    mu2Selection = cms.string ("pt>3 && abs(eta)<2.4"),
+    preVtxSelection = cms.string ("pt>5 && abs(eta)<2.4"),
+    postVtxSelection = cms.string ("userFloat('prob')>0.01"), # WP 0.01
+    RefitTracks = cms.bool (True),
+    FitTunePTransientTracks = cms.bool(True),
+)
+
+DiMuonTable = cms.EDProducer("SimpleCompositeCandidateFlatTableProducer",
+    src = cms.InputTag("DiMuonVertex","diMuons"),
+    cut = cms.string(""), #we should not filter on cross linked collections
+    name = cms.string("DiMuon"),
+    doc  = cms.string("dimuons that create a good vertex"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table for the muons
+    variables = cms.PSet(
+      CandVars,
+      fit_pt = Var("userFloat('fit_pt')",float,doc="fitted pT of dimuon system",precision=12),
+      fit_eta = Var("userFloat('fit_eta')",float,doc="fitted eta of dimuon system",precision=12),     
+      fit_phi = Var("userFloat('fit_phi')",float,doc="fitted phi of dimuon system",precision=12),
+      fit_mass = Var("userFloat('fit_mass')",float,doc="fitted mass of dimuon system",precision=-1),
+      vtx_prob = Var("userFloat('prob')",float,doc="Vertex probability",precision=12),
+      vtx_x = Var("userFloat('vtx_x')",float,doc="x of dimuon vtx",precision=12),
+      vtx_y = Var("userFloat('vtx_y')",float,doc="y of dimuon vtx",precision=12),
+      vtx_z = Var("userFloat('vtx_z')",float,doc="z of dimuon vtx",precision=12),
+      IP_fromBS = Var("userFloat('IP_fromBS')",float,doc="2D impact parameter measured from beamspot",precision=12),
+      SIP_fromBS = Var("userFloat('SIP_fromBS')",float,doc="significance of 2D impact parameter measured from beamspot",precision=12),
+      IP_fromPV = Var("userFloat('IP_fromPV')",float,doc="2D impact parameter measured from primary vertex",precision=12),
+      SIP_fromPV = Var("userFloat('SIP_fromPV')",float,doc="significance of 2D impact parameter measured from primary vertex",precision=12),
+      mu1_idx = Var("userInt('mu1_idx')",int,doc="idx of leading muon"),
+      mu2_idx = Var("userInt('mu2_idx')",int,doc="idx of subleading muon"),
+
+    )
+)

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -15,6 +15,7 @@ from PhysicsTools.NanoAOD.vertices_cff import *
 from PhysicsTools.NanoAOD.met_cff import *
 from PhysicsTools.NanoAOD.triggerObjects_cff import *
 from PhysicsTools.NanoAOD.isotracks_cff import *
+from PhysicsTools.NanoAOD.dimuons_cff import *
 from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import *
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
@@ -123,10 +124,10 @@ l1bits=cms.EDProducer("L1TriggerResultsConverter", src=cms.InputTag("gtStage2Dig
 (run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1).toModify(l1bits, storeUnprefireableBit=False)
 
 nanoSequenceCommon = cms.Sequence(
-        nanoMetadata + jetSequence + muonSequence + tauSequence + electronSequence+photonSequence+vertexSequence+
+        nanoMetadata + jetSequence + muonSequence + DiMuonVertex + tauSequence + electronSequence+photonSequence+vertexSequence+
         isoTrackSequence + jetLepSequence + # must be after all the leptons 
         linkedObjects  +
-        jetTables + muonTables + tauTables + electronTables + photonTables +  globalTables +vertexTables+ metTables+simpleCleanerTable + isoTrackTables
+        jetTables + muonTables +  DiMuonTable + tauTables + electronTables + photonTables +  globalTables +vertexTables+ metTables+simpleCleanerTable + isoTrackTables
         )
 nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectTables + l1bits)
 


### PR DESCRIPTION
Dear all, 

This PR is a continuation from the [now closed]  #490 . A list with the changes I performed according to your comments:

1) Changed to final muons
2) Added the dimuon producer in nano_cfg
3) Pushed only my files without the other push

Tests:
1) Run on 500 evts of ttbar [*] with size increase of 0.5%. In that sample we find average pairs/evt of 0.21
2) Run on 100evts in DY [**] with size increase of 0.4%.  In that sample we find average pairs/evt of 0.4

Let me know if anything else is needed. Thanks.

Best regards,
George


[*]  /store/mc/RunIISummer16MiniAODv3/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_94X_mcRun2_asymptotic_v3-v2/270000/5ABB0EC9-FCE9-E811-B517-0CC47A6C1056.root
[**] /store/mc/RunIIAutumn18MiniAOD/DYJetsToLL_M-50_Zpt-150toInf_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/60000/02BCC9C7-E0B2-B647-BEFB-71FB391741D7.root